### PR TITLE
fix(security): SCR-002, SCR-003, SCR-005

### DIFF
--- a/SDD.md
+++ b/SDD.md
@@ -1,0 +1,186 @@
+# SDD — Remediation of security findings (2026-08-04)
+
+Design for fixing the three actionable findings from [`SECURITY.md`](SECURITY.md). SCR-001,
+SCR-004 and SCR-006 are excluded on purpose — they require diverging from the wire protocol the
+Mac app speaks, which this repo cannot do unilaterally (see `CLAUDE.md`, "Protocolo — fonte da
+verdade"). All three fixes below are local to the Android app, don't touch framing/handshake, and
+don't require a corresponding change on the Mac side.
+
+## Goals
+
+- Close SCR-002 (bitmap decode DoS) and SCR-003 (unvalidated redirect URL) without changing any
+  byte on the wire.
+- Close SCR-005 (backup hardening) with a manifest-only change.
+- No new dependencies, no new abstractions — each fix stays inside the function that has the
+  problem, per the project's `simplicidade` convention.
+
+## Non-goals
+
+- Peer authentication, TLS, or any change to `Framing`/`AnnexB`/`WireProtocol` (that's SCR-001,
+  accepted risk, would break Mac compatibility).
+- Changing what `installId` is or how it's advertised (SCR-004, accepted risk, protocol requires
+  a stable per-device id).
+- Restricting which interface `ServerSocket` binds to (SCR-006, accepted risk, would break the
+  documented USB/`adb forward` path in `CLAUDE.md`).
+
+---
+
+## SCR-002: Validate cursor sprite dimensions before decoding
+
+**File:** `app/src/main/java/io/github/josepacelli/opendisplay/ui/CursorOverlay.kt`
+
+**Current behavior:** `decodeSprite` calls `BitmapFactory.decodeByteArray` directly on
+attacker-reachable bytes (`cursorImg` control message, base64-decoded in
+`PhoneReceiver.handleCursorImage`). A crafted PNG with a small file size but a huge `IHDR` can
+force an oversized allocation and crash the app (OOM) before any error handling has a chance to
+kick in.
+
+**Design:** Two-pass decode. First pass with `inJustDecodeBounds = true` (no pixel allocation,
+just reads the header) to get `outWidth`/`outHeight`, reject anything outside a sane cursor-sprite
+range before the real decode ever allocates memory. A remote cursor is, by definition, small —
+128px is already generous for a hotspot sprite; cap at 256 to leave headroom without being
+meaningless.
+
+```kotlin
+private const val MAX_SPRITE_DIMENSION_PX = 256
+
+private fun decodeSprite(image: CursorImage): DecodedSprite? {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(image.png, 0, image.png.size, bounds)
+    if (bounds.outWidth <= 0 || bounds.outHeight <= 0 ||
+        bounds.outWidth > MAX_SPRITE_DIMENSION_PX || bounds.outHeight > MAX_SPRITE_DIMENSION_PX
+    ) {
+        Log.warn("cursor sprite rejected: ${bounds.outWidth}x${bounds.outHeight}")
+        return null
+    }
+    val bitmap = try {
+        BitmapFactory.decodeByteArray(image.png, 0, image.png.size)?.asImageBitmap()
+    } catch (e: Exception) {
+        Log.warn("failed to decode cursor sprite", e)
+        null
+    } ?: return null
+    return DecodedSprite(bitmap, image.normalizedWidth, image.normalizedHeight, image.anchorX, image.anchorY)
+}
+```
+
+**Testing:** Unit test feeding a synthetic PNG byte array with `IHDR` claiming e.g. 8000×8000 but
+a tiny file — assert `decodeSprite` returns `null` and never calls the allocating decode path.
+Existing valid-sprite fixtures (if any) must still decode correctly at their real size.
+
+**Compatibility:** None — purely local decode logic, no wire format change. A real Mac never
+sends sprites anywhere near 256px, so this has zero effect on the legitimate path.
+
+---
+
+## SCR-003: Validate the `store` URL before it can ever be acted on
+
+**File:** `app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt`
+
+**Current behavior:** `handleControlJson`'s `UPDATE_REQUIRED` branch reads `obj.optString("store")`
+straight from an unauthenticated peer into `PeerSignal.UpdateAndroid.storeUrl`. Nothing renders it
+as a clickable link today, so there's no live exploit — but the field is a landmine for whoever
+wires up an "Update" button later without re-reading this finding.
+
+**Design:** Validate at the point of ingestion, not at the point of use — the wire boundary is the
+right place to enforce this, so future UI code never has to remember to. Only accept an `https://`
+URL whose host is the project's own domains (its GitHub org or the Play Store, if the app is ever
+published there). Anything else collapses to `null`, same as if `store` had never been sent.
+
+```kotlin
+// companion object of PhoneReceiver, alongside the other constants
+private val ALLOWED_STORE_HOSTS = setOf("github.com", "play.google.com")
+
+private fun sanitizedStoreUrl(raw: String?): String? {
+    if (raw.isNullOrBlank()) return null
+    val uri = try {
+        java.net.URI(raw)
+    } catch (e: Exception) {
+        return null
+    }
+    if (uri.scheme != "https") return null
+    if (uri.host !in ALLOWED_STORE_HOSTS) return null
+    return raw
+}
+```
+
+```kotlin
+WireMessage.UPDATE_REQUIRED -> {
+    val message = obj.optString(
+        "message",
+        "Atualize o OpenDisplay para continuar usando este segundo display.",
+    )
+    val store = sanitizedStoreUrl(if (obj.has("store")) obj.optString("store") else null)
+    _peerSignal.value = PeerSignal.UpdateAndroid(message, store)
+}
+```
+
+**Testing:** Unit test `sanitizedStoreUrl` with: a legit `https://github.com/...` URL (passes), a
+non-https URL, a `javascript:` URL, an arbitrary host (`https://evil.example`), and `null`/blank
+input — all four bad cases must return `null`.
+
+**Compatibility:** None — `storeUrl` is presentation-layer state derived from the message, never
+sent back on the wire.
+
+---
+
+## SCR-005: Harden backup extraction
+
+**File:** `app/src/main/AndroidManifest.xml`
+
+**Current behavior:** `android:allowBackup="true"` with no `dataExtractionRules`/
+`fullBackupContent`, so the app's `SharedPreferences` (`installId`, the mDNS service name) can be
+pulled via `adb backup` on an unlocked, debuggable device.
+
+**Design:** Add a `dataExtractionRules.xml` that excludes the `opendisplay` preferences file from
+both device-to-device transfer and cloud/`adb` backup, and point the manifest at it. Simpler than
+flipping `allowBackup` to `false` outright — this way if some future version adds something
+genuinely worth backing up (e.g. a UI preference), it opts in explicitly instead of the whole app
+being backup-blind forever.
+
+`app/src/main/res/xml/data_extraction_rules.xml` (new file):
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="opendisplay.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="opendisplay.xml" />
+    </device-transfer>
+</data-extraction-rules>
+```
+
+`AndroidManifest.xml` — add the attribute to the existing `<application>` tag:
+```xml
+<application
+    android:allowBackup="true"
+    android:dataExtractionRules="@xml/data_extraction_rules"
+    ...>
+```
+
+**Testing:** `./gradlew assembleDebug` (manifest merger validates the XML reference); manual
+check with `adb backup` on a debug build, confirm the `opendisplay` prefs file is absent from the
+extracted archive.
+
+**Compatibility:** None — `minSdk` 26 is well above the API 31 floor for
+`dataExtractionRules`; on API < 31 the attribute is simply ignored (that's `fullBackupContent`'s
+job pre-31, not worth adding given the low sensitivity of the data involved).
+
+---
+
+## Rollout
+
+All three are independent, no ordering dependency. Land as one PR (small, same theme, easy to
+review together) or three — either works; there's no reason to split given the total diff is
+under ~40 lines across 3 files plus one new XML resource.
+
+## Out of scope (accepted risks, no design here)
+
+- **SCR-001** (no peer auth) — would require a pairing/handshake step the Mac app doesn't speak.
+- **SCR-004** (install ID over mDNS) — the Mac uses this id to correlate reconnects; removing it
+  breaks reconnection behavior.
+- **SCR-006** (listener bound to all interfaces) — required for the USB/`adb forward` path
+  documented in `CLAUDE.md`.
+
+If any of these ever need to change, it has to start upstream in `peetzweg/opendisplay`'s
+protocol, not in this client alone.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security
+
+## Reporting a vulnerability
+
+This is a small, unfunded open-source project with no bug bounty. If you find a security issue,
+please open a [GitHub issue](https://github.com/josepacelli/opendisplay-android/issues) or a
+private security advisory on the repository. Include steps to reproduce and, if possible, which
+finding ID below (if any) it relates to.
+
+## Threat model, in short
+
+- The Android app **listens** on a raw TCP socket (port 9000, no TLS) and the Mac **connects** to
+  it — same protocol as the original [OpenDisplay](https://github.com/peetzweg/opendisplay) Mac
+  app, unmodified. This is a deliberate, documented design choice (no account, no central server,
+  see the project README) and cannot diverge from it without breaking interoperability with the
+  Mac app.
+- The trust boundary is **the local network**: anyone who can reach the phone/tablet's IP on the
+  same WiFi (or a routed subnet) can connect to port 9000. There is no authentication of the peer
+  — this mirrors the upstream iOS client's behavior exactly, not a gap introduced by this port.
+- Given that boundary, findings below are classified by what an unauthenticated device on the same
+  network can actually do, not by internet-facing severity norms.
+
+## Security review — 2026-08-04
+
+Structured review against OWASP ASVS 4.0.3 / CWE Top 25, scoped to the network/protocol layer
+(`net/`, `protocol/`, `video/VideoDecoder.kt`, `service/ReceiverService.kt`,
+`ui/SettingsDialog.kt`, `ui/CursorOverlay.kt`, `ui/ReceiverScreen.kt`, `AndroidManifest.xml`,
+`gradle/libs.versions.toml`).
+
+| ID | Title | Severity | CWE | Status |
+|---|---|---|---|---|
+| SCR-001 | No peer authentication on the control/video socket | Medium | CWE-306 | Accepted risk (inherited from upstream protocol) |
+| SCR-002 | Cursor sprite bitmap decoded without dimension validation | Medium | CWE-400 | Open — see [SDD.md](SDD.md) |
+| SCR-003 | Unvalidated `store` URL forwarded from an untrusted peer | Low | CWE-601 | Open — see [SDD.md](SDD.md) |
+| SCR-004 | Persistent install ID broadcast in cleartext over mDNS | Informational | CWE-200 | Accepted risk (required by protocol) |
+| SCR-005 | `allowBackup="true"` with no data extraction rules | Informational | CWE-312 | Open — see [SDD.md](SDD.md) |
+| SCR-006 | Listener bound to all network interfaces, not just WiFi | Informational | — | Accepted risk (required for the documented USB/`adb forward` path) |
+
+Remediation design for the three actionable findings (SCR-002, SCR-003, SCR-005) is in
+[`SDD.md`](SDD.md). SCR-001, SCR-004 and SCR-006 are accepted risks: fixing them would mean
+diverging from the wire protocol the Mac app speaks, which this project cannot do unilaterally
+(see `CLAUDE.md`'s "Protocolo — fonte da verdade" section).
+
+## What this app deliberately does not have
+
+No accounts, no telemetry, no central server, no TLS on the wire protocol — same philosophy as
+the original OpenDisplay project. Anything that requires the Mac app to change is out of scope
+for this repository.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
 
     <application
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.OpenDisplay"

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -99,6 +99,23 @@ class PhoneReceiver(context: Context) {
         private const val WATCHDOG_TIMEOUT_MS = 5_000L
         private const val PING_INTERVAL_MS = 2_000L
         private const val READ_BUFFER_SIZE = 64 * 1024
+        private val ALLOWED_STORE_HOSTS = setOf("github.com", "play.google.com")
+
+        /** The `store` field on `updateRequired` comes from an unauthenticated peer (the Mac
+         * side of this socket has no auth — see SECURITY.md/SCR-001) — validated here, at the
+         * wire boundary, so no future UI code has to remember to sanitize it before turning it
+         * into a clickable link/intent. */
+        internal fun sanitizedStoreUrl(raw: String?): String? {
+            if (raw.isNullOrBlank()) return null
+            val uri = try {
+                java.net.URI(raw)
+            } catch (e: Exception) {
+                return null
+            }
+            if (uri.scheme != "https") return null
+            if (uri.host !in ALLOWED_STORE_HOSTS) return null
+            return raw
+        }
     }
 
     private val appContext = context.applicationContext
@@ -490,7 +507,7 @@ class PhoneReceiver(context: Context) {
                     "message",
                     "Atualize o OpenDisplay para continuar usando este segundo display.",
                 )
-                val store = if (obj.has("store")) obj.optString("store") else null
+                val store = sanitizedStoreUrl(if (obj.has("store")) obj.optString("store") else null)
                 _peerSignal.value = PeerSignal.UpdateAndroid(message, store)
             }
 

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/CursorOverlay.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/CursorOverlay.kt
@@ -64,7 +64,20 @@ fun CursorOverlay(receiver: PhoneReceiver, modifier: Modifier = Modifier) {
     }
 }
 
+/** A remote cursor sprite is a small hotspot icon by definition — this caps how big a
+ * peer-supplied PNG can claim to be before it's actually decoded (bounds-only pass first),
+ * so a crafted header with huge dimensions can't force an oversized allocation. */
+private const val MAX_SPRITE_DIMENSION_PX = 256
+
 private fun decodeSprite(image: CursorImage): DecodedSprite? {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(image.png, 0, image.png.size, bounds)
+    if (bounds.outWidth <= 0 || bounds.outHeight <= 0 ||
+        bounds.outWidth > MAX_SPRITE_DIMENSION_PX || bounds.outHeight > MAX_SPRITE_DIMENSION_PX
+    ) {
+        Log.warn("cursor sprite rejected: ${bounds.outWidth}x${bounds.outHeight}")
+        return null
+    }
     val bitmap = try {
         BitmapFactory.decodeByteArray(image.png, 0, image.png.size)?.asImageBitmap()
     } catch (e: Exception) {

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="opendisplay.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="opendisplay.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/test/java/io/github/josepacelli/opendisplay/net/PhoneReceiverStoreUrlTest.kt
+++ b/app/src/test/java/io/github/josepacelli/opendisplay/net/PhoneReceiverStoreUrlTest.kt
@@ -1,0 +1,39 @@
+package io.github.josepacelli.opendisplay.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** SCR-003: `store` comes from an unauthenticated peer — must collapse to null
+ * unless it's an https URL on an allowed host, never passed through as-is. */
+class PhoneReceiverStoreUrlTest {
+
+    @Test
+    fun `accepts an https URL on an allowed host`() {
+        val url = "https://github.com/josepacelli/opendisplay-android/releases/latest"
+        assertEquals(url, PhoneReceiver.sanitizedStoreUrl(url))
+    }
+
+    @Test
+    fun `rejects a non-https scheme`() {
+        assertNull(PhoneReceiver.sanitizedStoreUrl("http://github.com/x"))
+        assertNull(PhoneReceiver.sanitizedStoreUrl("javascript:alert(1)"))
+    }
+
+    @Test
+    fun `rejects a host outside the allowlist`() {
+        assertNull(PhoneReceiver.sanitizedStoreUrl("https://evil.example/x"))
+    }
+
+    @Test
+    fun `rejects null and blank input`() {
+        assertNull(PhoneReceiver.sanitizedStoreUrl(null))
+        assertNull(PhoneReceiver.sanitizedStoreUrl(""))
+        assertNull(PhoneReceiver.sanitizedStoreUrl("   "))
+    }
+
+    @Test
+    fun `rejects malformed URIs`() {
+        assertNull(PhoneReceiver.sanitizedStoreUrl("not a url"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adiciona `SECURITY.md` (política de disclosure + tabela dos 6 findings da revisão de 2026-08-04) e `SDD.md` (design das correções).
- SCR-002: valida dimensões do sprite do cursor antes do decode real do bitmap (bounds-only pass primeiro) — evita OOM por PNG malicioso com header inflado.
- SCR-003: valida a URL de `store` do `updateRequired` (esquema `https` + host allowlist) na ingestão, já que vem de um peer não autenticado.
- SCR-005: exclui o `SharedPreferences` do app do backup/transferência via `dataExtractionRules.xml`.

SCR-001, SCR-004 e SCR-006 ficam documentados como risco aceito — exigiriam divergir do protocolo que o app Mac fala, fora do escopo deste client (ver `SDD.md`).

## Test plan
- [x] `./gradlew assembleDebug` — build ok
- [x] `./gradlew testDebugUnitTest` — 22/22 (5 novos testes em `PhoneReceiverStoreUrlTest`)
- [x] Instalado num tablet real via wifi debug, conectado com o Mac real: `new connection` → `hello sent (2880x1800 @1.75x)` → `MediaCodec configured` → `decoder output format changed` — handshake e vídeo normais, sem regressão no wire protocol