### PR TITLE
fix(main): guard WindowMetrics.getDensity() behind API 34

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
@@ -101,14 +101,16 @@ class MainActivity : ComponentActivity() {
      * wrong there. Falls back to `DisplayMetrics` below API 30 (minSdk 26).
      */
     private fun reportPanelSize(receiver: PhoneReceiver) {
+        val density = resources.displayMetrics.density.toDouble()
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val metrics = windowManager.currentWindowMetrics
             val bounds = metrics.bounds
-            receiver.setPanelSize(bounds.width(), bounds.height(), metrics.density.toDouble())
+            receiver.setPanelSize(bounds.width(), bounds.height(), density)
         } else {
             @Suppress("DEPRECATION")
             val metrics = resources.displayMetrics
-            receiver.setPanelSize(metrics.widthPixels, metrics.heightPixels, metrics.density.toDouble())
+            receiver.setPanelSize(metrics.widthPixels, metrics.heightPixels, density)
         }
     }
 }


### PR DESCRIPTION
reportPanelSize() guarded its modern path with SDK_INT >= R, which is correct for WindowManager.currentWindowMetrics and WindowMetrics.bounds (both API 30) but not for WindowMetrics.getDensity(), added in API 34.
On API 30-33 the class resolves and the method does not, so the call threw NoSuchMethodError from onServiceConnected and killed the process on every launch.

Read density from resources.displayMetrics instead, which is valid at all API levels and is documented as equivalent to WindowMetrics.getDensity().
Bounds handling is unchanged: the API 30+ path still uses currentWindowMetrics for correct multi-window sizing.

Fixes #4