### PR TITLE
Show app version and About info in Settings dialog

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
@@ -1,9 +1,12 @@
 package io.github.josepacelli.opendisplay.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -14,7 +17,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.josepacelli.opendisplay.R
@@ -32,6 +38,12 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
     val currentName by receiver.serviceName.collectAsState()
     var draftName by remember { mutableStateOf(currentName) }
     val addressHint = remember { receiver.localAddressHint() }
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    val versionName = remember {
+        @Suppress("DEPRECATION")
+        runCatching { context.packageManager.getPackageInfo(context.packageName, 0).versionName }.getOrNull()
+    }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -57,6 +69,21 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(top = 4.dp),
                 )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = versionName?.let { stringResource(R.string.about_version, it) }
+                            ?: stringResource(R.string.about_version_unknown),
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                    TextButton(onClick = {
+                        uriHandler.openUri("https://github.com/josepacelli/opendisplay-android")
+                    }) { Text(stringResource(R.string.about_github)) }
+                }
             }
         },
         confirmButton = {

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -16,4 +16,8 @@
     <string name="settings_cancel">Cancelar</string>
 
     <string name="peer_replaced_warning">Conexão assumida por outro dispositivo (%1$s). Se não foi você, verifique quem está na rede.</string>
+
+    <string name="about_version">OpenDisplay v%1$s · GPL-3.0</string>
+    <string name="about_version_unknown">OpenDisplay · GPL-3.0</string>
+    <string name="about_github">GitHub</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,8 @@
     <string name="settings_cancel">Cancel</string>
 
     <string name="peer_replaced_warning">Connection taken over by another device (%1$s). If this wasn\'t you, check who\'s on the network.</string>
+
+    <string name="about_version">OpenDisplay v%1$s · GPL-3.0</string>
+    <string name="about_version_unknown">OpenDisplay · GPL-3.0</string>
+    <string name="about_github">GitHub</string>
 </resources>


### PR DESCRIPTION
## Summary

- Added a small About footer to the existing `SettingsDialog` — version (read at runtime via `PackageManager`, no `BuildConfig` needed), license, and a link to the GitHub repo.
- No new screen/navigation concept introduced: this app has no nav stack, every bit of chrome so far is a dialog overlay, so this reuses that pattern.

Fixes #8

## Test plan

- [x] `./gradlew assembleDebug testDebugUnitTest` passes
- [x] Verified on-device (Samsung Tab S10 FE): Settings dialog now shows "OpenDisplay v0.0.10 · GPL-3.0" and a working GitHub link