### PR TITLE
Redesign idle and settings screens to match upstream iOS client

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/ReceiverScreen.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/ReceiverScreen.kt
@@ -1,16 +1,25 @@
 package io.github.josepacelli.opendisplay.ui
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -19,7 +28,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.josepacelli.opendisplay.R
@@ -74,18 +85,7 @@ fun ReceiverScreen(receiver: PhoneReceiver) {
             // Scrim over the video box — otherwise the last decoded frame
             // stays visible behind the status text after a disconnect.
             Box(modifier = Modifier.fillMaxSize().background(Color.Black))
-            Text(
-                text = status,
-                color = Color.White,
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(24.dp),
-            )
-            TextButton(
-                onClick = { showSettings = true },
-                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 32.dp),
-            ) {
-                Text(stringResource(R.string.settings_title), color = Color.White)
-            }
+            IdleContent(status = status, onSettingsClick = { showSettings = true })
         }
 
         peerSignal?.let { signal ->
@@ -99,6 +99,72 @@ fun ReceiverScreen(receiver: PhoneReceiver) {
 
     if (showSettings) {
         SettingsDialog(receiver = receiver, onDismiss = { showSettings = false })
+    }
+}
+
+/**
+ * No-Mac-connected state — mirrors the upstream iOS client's `IdleView`:
+ * logo, title, a colored status dot, a short instructions card and a
+ * proper Settings button, instead of a bare status line.
+ */
+@Composable
+private fun IdleContent(status: String, onSettingsClick: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.widthIn(max = 420.dp).padding(24.dp),
+    ) {
+        // The app icon is an adaptive icon (mipmap XML with separate
+        // background/foreground layers) — painterResource can't load that
+        // directly, so recreate the round launcher look from its layers.
+        Box(
+            modifier = Modifier.size(96.dp).clip(CircleShape).background(Color.White),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                painter = painterResource(R.drawable.ic_launcher_foreground),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.app_name),
+            color = Color.White,
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            // This content only renders while disconnected — the dot mirrors
+            // the iOS IdleView's semantics (green = connected), so it's
+            // orange here by construction, not a value read from `status`.
+            Box(modifier = Modifier.size(8.dp).background(Color(0xFFFFA000), CircleShape))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text = status, color = Color.White.copy(alpha = 0.8f), style = MaterialTheme.typography.bodyMedium)
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Surface(
+            color = Color.White.copy(alpha = 0.08f),
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                InstructionRow(stringResource(R.string.idle_instruction_wifi))
+                Spacer(modifier = Modifier.height(14.dp))
+                InstructionRow(stringResource(R.string.idle_instruction_keep_open))
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        OutlinedButton(onClick = onSettingsClick) {
+            Text(stringResource(R.string.settings_title))
+        }
+    }
+}
+
+@Composable
+private fun InstructionRow(text: String) {
+    Row(verticalAlignment = Alignment.Top) {
+        Text(text = "•", color = Color.White.copy(alpha = 0.8f), style = MaterialTheme.typography.bodySmall)
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(text = text, color = Color.White.copy(alpha = 0.9f), style = MaterialTheme.typography.bodySmall)
     }
 }
 

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
@@ -5,6 +5,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -27,15 +30,16 @@ import io.github.josepacelli.opendisplay.R
 import io.github.josepacelli.opendisplay.net.PhoneReceiver
 
 /**
- * The only "settings" this receiver has: the mDNS name the Mac's WiFi picker
- * shows, and — for when mDNS doesn't reach it (some networks block
- * multicast) — this device's own IP address to type into the Mac app's host
- * override by hand. Shown only while disconnected; once video is flowing
- * this app has no chrome at all.
+ * Grouped like the upstream iOS client's `SettingsView` (`Form` with
+ * sections), adapted to what's actually true on Android: no USB / Metal
+ * renderer / Local Network permission items — this app only ever listens
+ * on plain TCP, so there's nothing OS-specific to toggle. Shown only while
+ * disconnected; once video is flowing this app has no chrome at all.
  */
 @Composable
 fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
     val currentName by receiver.serviceName.collectAsState()
+    val connected by receiver.connected.collectAsState()
     var draftName by remember { mutableStateOf(currentName) }
     val addressHint = remember { receiver.localAddressHint() }
     val context = LocalContext.current
@@ -49,40 +53,75 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.settings_title)) },
         text = {
-            Column {
-                Text(
-                    text = stringResource(R.string.settings_name_label),
-                    style = MaterialTheme.typography.bodySmall,
-                )
-                OutlinedTextField(
-                    value = draftName,
-                    onValueChange = { draftName = it },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 16.dp),
-                )
-                Text(
-                    text = stringResource(R.string.settings_manual_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                )
-                Text(
-                    text = addressHint ?: stringResource(R.string.settings_address_unavailable),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(top = 4.dp),
-                )
-                HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = versionName?.let { stringResource(R.string.about_version, it) }
-                            ?: stringResource(R.string.about_version_unknown),
-                        style = MaterialTheme.typography.labelSmall,
+            Column(modifier = Modifier.widthIn(max = 420.dp).verticalScroll(rememberScrollState())) {
+                SettingsSection(stringResource(R.string.settings_section_status)) {
+                    LabeledRow(
+                        stringResource(R.string.settings_status_listening),
+                        stringResource(R.string.settings_status_listening_value, PhoneReceiver.DEFAULT_PORT),
                     )
-                    TextButton(onClick = {
-                        uriHandler.openUri("https://github.com/josepacelli/opendisplay-android")
-                    }) { Text(stringResource(R.string.about_github)) }
+                    LabeledRow(
+                        stringResource(R.string.settings_status_connection),
+                        stringResource(
+                            if (connected) R.string.settings_status_connection_connected
+                            else R.string.settings_status_connection_waiting,
+                        ),
+                    )
+                }
+
+                SettingsSection(stringResource(R.string.settings_section_name)) {
+                    Text(
+                        text = stringResource(R.string.settings_name_label),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    OutlinedTextField(
+                        value = draftName,
+                        onValueChange = { draftName = it },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    )
+                }
+
+                SettingsSection(stringResource(R.string.settings_section_network)) {
+                    Text(
+                        text = stringResource(R.string.settings_manual_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Text(
+                        text = addressHint ?: stringResource(R.string.settings_address_unavailable),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+
+                SettingsSection(stringResource(R.string.settings_section_how_to_connect)) {
+                    Text(stringResource(R.string.settings_howto_wifi), style = MaterialTheme.typography.bodySmall)
+                    Text(
+                        stringResource(R.string.settings_howto_rotate),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                    Text(
+                        stringResource(R.string.settings_howto_touch),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                }
+
+                SettingsSection(stringResource(R.string.settings_section_about), showDivider = false) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = versionName?.let { stringResource(R.string.about_version, it) }
+                                ?: stringResource(R.string.about_version_unknown),
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                        TextButton(onClick = {
+                            uriHandler.openUri("https://github.com/josepacelli/opendisplay-android")
+                        }) { Text(stringResource(R.string.about_github)) }
+                    }
                 }
             }
         },
@@ -96,4 +135,28 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.settings_cancel)) }
         },
     )
+}
+
+@Composable
+private fun SettingsSection(title: String, showDivider: Boolean = true, content: @Composable () -> Unit) {
+    Column(modifier = Modifier.padding(top = 12.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Column(modifier = Modifier.padding(top = 6.dp)) { content() }
+        if (showDivider) HorizontalDivider(modifier = Modifier.padding(top = 12.dp))
+    }
+}
+
+@Composable
+private fun LabeledRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodyMedium)
+        Text(text = value, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
 }

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -8,15 +8,31 @@
 
     <string name="notification_waiting">Aguardando seu Mac conectar…</string>
 
+    <string name="idle_instruction_wifi">Escolha este aparelho em WiFi no app do Mac</string>
+    <string name="idle_instruction_keep_open">Mantenha este app aberto — a transmissão começa automaticamente</string>
+
     <string name="settings_title">Configurações</string>
+    <string name="settings_section_status">Status</string>
+    <string name="settings_status_listening">Escutando</string>
+    <string name="settings_status_listening_value">Porta %1$d</string>
+    <string name="settings_status_connection">Conexão</string>
+    <string name="settings_status_connection_waiting">Aguardando o Mac</string>
+    <string name="settings_status_connection_connected">Conectado</string>
+    <string name="settings_section_name">Nome</string>
     <string name="settings_name_label">Nome anunciado na rede (aparece no menu de conexão do Mac):</string>
+    <string name="settings_section_network">Rede</string>
     <string name="settings_manual_hint">Se o Mac não encontrar este aparelho automaticamente por WiFi, informe o endereço abaixo manualmente no app do Mac:</string>
     <string name="settings_address_unavailable">Endereço IP indisponível — verifique a conexão WiFi.</string>
+    <string name="settings_section_how_to_connect">Como conectar</string>
+    <string name="settings_howto_wifi">Os dois aparelhos na mesma rede WiFi e depois escolha este aparelho no menu de conexão do app do Mac.</string>
+    <string name="settings_howto_rotate">Gire o aparelho pra um segundo monitor vertical.</string>
+    <string name="settings_howto_touch">Toque: tocar clica, arrastar arrasta, dois dedos rola a tela.</string>
     <string name="settings_save">Salvar</string>
     <string name="settings_cancel">Cancelar</string>
 
     <string name="peer_replaced_warning">Conexão assumida por outro dispositivo (%1$s). Se não foi você, verifique quem está na rede.</string>
 
+    <string name="settings_section_about">Sobre</string>
     <string name="about_version">OpenDisplay v%1$s · GPL-3.0</string>
     <string name="about_version_unknown">OpenDisplay · GPL-3.0</string>
     <string name="about_github">GitHub</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,15 +8,31 @@
 
     <string name="notification_waiting">Waiting for your Mac to connect…</string>
 
+    <string name="idle_instruction_wifi">Choose this device under WiFi in the Mac app</string>
+    <string name="idle_instruction_keep_open">Keep this app open — streaming starts automatically</string>
+
     <string name="settings_title">Settings</string>
+    <string name="settings_section_status">Status</string>
+    <string name="settings_status_listening">Listening</string>
+    <string name="settings_status_listening_value">Port %1$d</string>
+    <string name="settings_status_connection">Connection</string>
+    <string name="settings_status_connection_waiting">Waiting for Mac</string>
+    <string name="settings_status_connection_connected">Connected</string>
+    <string name="settings_section_name">Name</string>
     <string name="settings_name_label">Name announced on the network (shown in the Mac\'s connection menu):</string>
+    <string name="settings_section_network">Network</string>
     <string name="settings_manual_hint">If the Mac can\'t find this device automatically over WiFi, enter the address below manually in the Mac app:</string>
     <string name="settings_address_unavailable">IP address unavailable — check your WiFi connection.</string>
+    <string name="settings_section_how_to_connect">How to connect</string>
+    <string name="settings_howto_wifi">Both devices on the same WiFi network, then pick this device in the Mac app\'s connection menu.</string>
+    <string name="settings_howto_rotate">Rotate the device for a vertical second monitor.</string>
+    <string name="settings_howto_touch">Touch: tap to click, drag to drag, two-finger pan to scroll.</string>
     <string name="settings_save">Save</string>
     <string name="settings_cancel">Cancel</string>
 
     <string name="peer_replaced_warning">Connection taken over by another device (%1$s). If this wasn\'t you, check who\'s on the network.</string>
 
+    <string name="settings_section_about">About</string>
     <string name="about_version">OpenDisplay v%1$s · GPL-3.0</string>
     <string name="about_version_unknown">OpenDisplay · GPL-3.0</string>
     <string name="about_github">GitHub</string>


### PR DESCRIPTION
## Summary
- Idle screen (`ReceiverScreen.kt`): app logo, title, colored status dot, an instructions card ("Choose this device under WiFi in the Mac app" / "Keep this app open"), and a proper outlined Settings button — replacing the bare status line + text button.
- Settings (`SettingsDialog.kt`): grouped into sections (Status, Name, Network, How to connect, About) mirroring the upstream iOS client's `Form`-based `SettingsView` (`iOS/OpenSidecarPhoneApp.swift`), adapted to Android reality — no USB / Metal-renderer / Local-Network-permission items, since those are iOS-specific concerns.
- New/adjusted strings added to both `values/strings.xml` and `values-pt/strings.xml`.
- No new dependencies: instructions use a plain text bullet instead of Material Icons, and the logo reuses the existing adaptive-icon vector layers (`ic_launcher_foreground` over a white circle) instead of `painterResource(R.mipmap.ic_launcher)`, which crashes on adaptive icons.

Fixes #11

## Test plan
- [x] `./gradlew assembleDebug testDebugUnitTest` — build and 17/17 unit tests pass
- [x] Installed on a real tablet (SM-X626B) over WiFi ADB; verified idle screen (logo/status dot/instructions/button) and Settings dialog (all five sections, Save/Cancel) render correctly in both English and pt-BR