### PR TITLE
Keep screen on while app is open

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
@@ -8,6 +8,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -55,6 +56,12 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // Mirrors iOS's `isIdleTimerDisabled = true`: this app IS the screen
+        // while it's open, so the system's inactivity timeout must not fire
+        // (issue #10). Doesn't block a manual power-button lock — screen
+        // lock/unlock still goes through PhoneReceiver.enterSleep()/wake()
+        // via ReceiverService's SCREEN_OFF/USER_PRESENT receiver.
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         val serviceIntent = Intent(this, ReceiverService::class.java)
         startForegroundService(serviceIntent)


### PR DESCRIPTION
## Summary
- `MainActivity.onCreate` now sets `WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON`, mirroring the upstream iOS client's `UIApplication.shared.isIdleTimerDisabled = true` — the app IS the screen while it's open, so the system's inactivity timeout must not turn it off.
- The second part of the report ("doesn't reconnect after the screen comes back") was already handled: `ReceiverService`'s `ACTION_SCREEN_OFF`/`ACTION_USER_PRESENT` receiver calls `PhoneReceiver.enterSleep()`/`wake()`, which re-arms listening correctly. With the timeout itself gone, that path is now only exercised by a deliberate power-button lock (same as iOS), not by idle timeout.

Fixes #10

## Test plan
- [x] `./gradlew assembleDebug testDebugUnitTest` — 17/17 unit tests pass