### PR TITLE
feat: show connection status, version, and a disconnect action in the notification

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -285,6 +285,18 @@ class PhoneReceiver(context: Context) {
         }
     }
 
+    /** User-initiated disconnect (the status bar notification's "Disconnect"
+     * action) — same `closing` semantics as [shutDown] so the Mac doesn't
+     * linger waiting for a wake, but unlike [shutDown] this keeps listening
+     * and advertising, so picking this device again on the Mac reconnects
+     * right away instead of needing the app relaunched. */
+    fun disconnect() {
+        scope.launch(Dispatchers.IO) {
+            if (connected.value) sendControlBlocking(JSONObject().put("type", WireMessage.CLOSING))
+            closeConnection()
+        }
+    }
+
     /** Real panel size in pixels + density, from the Activity/Compose layer.
      * Re-sends `hello` if we're already connected and the size actually
      * changed (rotation) — mirrors `setOrientation` on iOS, which rebuilds
@@ -404,7 +416,7 @@ class PhoneReceiver(context: Context) {
         outputStream = client.getOutputStream()
         lastDataReceivedAt = System.currentTimeMillis()
         _connected.value = true
-        _status.value = "Connected"
+        _status.value = appContext.getString(R.string.settings_status_connection_connected)
         if (devicePixelsWide == 0) {
             Log.warn("sending hello before panel size is known — caller should call setPanelSize() first")
         }
@@ -441,7 +453,7 @@ class PhoneReceiver(context: Context) {
                 socket = null
                 outputStream = null
                 _connected.value = false
-                _status.value = "Listening on :$lastBoundPort"
+                _status.value = appContext.getString(R.string.status_listening, lastBoundPort)
             }
             try {
                 client.close()

--- a/app/src/main/java/io/github/josepacelli/opendisplay/service/ReceiverService.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/service/ReceiverService.kt
@@ -18,6 +18,12 @@ import io.github.josepacelli.opendisplay.MainActivity
 import io.github.josepacelli.opendisplay.R
 import io.github.josepacelli.opendisplay.net.PhoneReceiver
 import io.github.josepacelli.opendisplay.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 
 /**
  * Foreground service so the TCP listener + NSD advertisement survive past
@@ -44,6 +50,8 @@ class ReceiverService : Service() {
     private val binder = LocalBinder()
     lateinit var receiver: PhoneReceiver
         private set
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private var screenReceiverRegistered = false
     private val screenReceiver = object : BroadcastReceiver() {
@@ -73,10 +81,20 @@ class ReceiverService : Service() {
         receiver = PhoneReceiver(applicationContext)
         startForeground(NOTIFICATION_ID, buildNotification())
         registerScreenReceiver()
+        // Status/connection change -> the notification is the only UI visible
+        // while the app isn't in the foreground, so it needs to stay live too.
+        serviceScope.launch {
+            combine(receiver.status, receiver.connected) { _, _ -> Unit }
+                .collect { updateNotification() }
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        receiver.start() // idempotent — safe if already running
+        if (intent?.action == ACTION_DISCONNECT) {
+            receiver.disconnect()
+        } else {
+            receiver.start() // idempotent — safe if already running
+        }
         return START_STICKY
     }
 
@@ -95,6 +113,7 @@ class ReceiverService : Service() {
     override fun onDestroy() {
         unregisterScreenReceiverIfNeeded()
         receiver.shutDown()
+        serviceScope.cancel()
         super.onDestroy()
     }
 
@@ -136,25 +155,43 @@ class ReceiverService : Service() {
             manager.createNotificationChannel(channel)
         }
         val openIntent = Intent(this, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(
+        val contentIntent = PendingIntent.getActivity(
             this,
             0,
             openIntent,
             PendingIntent.FLAG_IMMUTABLE,
         )
-        // TODO(fase 9): dedicated status icon/text (fps, transport) instead
-        // of this static placeholder — needs a real launcher-style small icon.
-        return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle(getString(R.string.app_name))
-            .setContentText(getString(R.string.notification_waiting))
+        // TODO(fase 9): dedicated status icon instead of this system
+        // placeholder — needs a real launcher-style small icon.
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.notification_title, versionName() ?: "?"))
+            .setContentText(receiver.status.value)
             .setSmallIcon(android.R.drawable.presence_video_online)
-            .setContentIntent(pendingIntent)
+            .setContentIntent(contentIntent)
             .setOngoing(true)
-            .build()
+        if (receiver.connected.value) {
+            val disconnectIntent = PendingIntent.getService(
+                this,
+                0,
+                Intent(this, ReceiverService::class.java).setAction(ACTION_DISCONNECT),
+                PendingIntent.FLAG_IMMUTABLE,
+            )
+            builder.addAction(
+                android.R.drawable.ic_lock_power_off,
+                getString(R.string.notification_action_disconnect),
+                disconnectIntent,
+            )
+        }
+        return builder.build()
     }
+
+    @Suppress("DEPRECATION")
+    private fun versionName(): String? =
+        runCatching { packageManager.getPackageInfo(packageName, 0).versionName }.getOrNull()
 
     companion object {
         private const val NOTIFICATION_ID = 1
         private const val CHANNEL_ID = "opendisplay_receiver"
+        private const val ACTION_DISCONNECT = "io.github.josepacelli.opendisplay.action.DISCONNECT"
     }
 }

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -6,7 +6,7 @@
     <string name="status_stopped">Parado</string>
     <string name="status_listening">Escutando na porta :%1$d</string>
 
-    <string name="notification_title">OpenDisplay · v%1$s</string>
+    <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desconectar</string>
 
     <string name="idle_instruction_wifi">Escolha este aparelho em WiFi no app do Mac</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -6,7 +6,8 @@
     <string name="status_stopped">Parado</string>
     <string name="status_listening">Escutando na porta :%1$d</string>
 
-    <string name="notification_waiting">Aguardando seu Mac conectar…</string>
+    <string name="notification_title">OpenDisplay · v%1$s</string>
+    <string name="notification_action_disconnect">Desconectar</string>
 
     <string name="idle_instruction_wifi">Escolha este aparelho em WiFi no app do Mac</string>
     <string name="idle_instruction_keep_open">Mantenha este app aberto — a transmissão começa automaticamente</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,8 @@
     <string name="status_stopped">Stopped</string>
     <string name="status_listening">Listening on :%1$d</string>
 
-    <string name="notification_waiting">Waiting for your Mac to connect…</string>
+    <string name="notification_title">OpenDisplay · v%1$s</string>
+    <string name="notification_action_disconnect">Disconnect</string>
 
     <string name="idle_instruction_wifi">Choose this device under WiFi in the Mac app</string>
     <string name="idle_instruction_keep_open">Keep this app open — streaming starts automatically</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="status_stopped">Stopped</string>
     <string name="status_listening">Listening on :%1$d</string>
 
-    <string name="notification_title">OpenDisplay · v%1$s</string>
+    <string name="notification_title">OpenDisplay for Android · v%1$s</string>
     <string name="notification_action_disconnect">Disconnect</string>
 
     <string name="idle_instruction_wifi">Choose this device under WiFi in the Mac app</string>


### PR DESCRIPTION
## Summary
- `ReceiverService`'s persistent notification now reacts live to `PhoneReceiver.status`/`connected` instead of staying a static placeholder, shows the app version, and adds a "Disconnect" action.
- New `PhoneReceiver.disconnect()` — same `closing` wire message semantics as `shutDown()`, but keeps listening/advertising so the Mac can reconnect immediately instead of needing the app relaunched.
- Fixed two pre-existing hardcoded English status strings in `PhoneReceiver` ("Connected", "Listening on :$port") that never went through `getString()` — this surfaced during testing because the notification now displays that text where it used to only show in a small idle-screen label, and stayed in English even on a pt-BR device.
- Notification title: "OpenDisplay for Android" / "OpenDisplay para Android".

Fixes #22

## Test plan
- [x] `./gradlew assembleDebug testDebugUnitTest` — build + tests pass
- [x] Installed on tablet: verified notification shows title+version, status text (disconnected/listening and connected, both correctly in pt-BR), and that "Desconectar" appears only while connected and actually drops the session back to listening without needing an app restart

## Note (separate, pre-existing gap — not in scope here)
While testing this, found the app never actually requests the `POST_NOTIFICATIONS` runtime permission (Android 13+) — it's declared in the manifest but nothing calls the runtime prompt, so on a fresh install the notification (this new one included) can silently never show until the user grants it manually via system settings. Worth its own issue.