### PR TITLE
feat: add a setting to show/hide the status notification

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -101,6 +101,7 @@ class PhoneReceiver(context: Context) {
         private const val PREFS_NAME = "opendisplay"
         private const val KEY_INSTALL_ID = "installID"
         private const val KEY_SERVICE_NAME = "serviceName"
+        private const val KEY_SHOW_NOTIFICATION = "showNotification"
         private const val DEFAULT_SERVICE_NAME = "OpenDisplay Android"
         private const val WATCHDOG_TIMEOUT_MS = 5_000L
         private const val PING_INTERVAL_MS = 2_000L
@@ -191,6 +192,12 @@ class PhoneReceiver(context: Context) {
      * generic "iPhone" without an entitlement personal teams can't get). */
     private val _serviceName = MutableStateFlow(loadServiceName())
     val serviceName: StateFlow<String> = _serviceName.asStateFlow()
+
+    /** Whether [io.github.josepacelli.opendisplay.service.ReceiverService] should
+     * show its status notification (connection status, version, disconnect
+     * action — see #22) — user-editable in Settings (#26). Defaults on. */
+    private val _showNotification = MutableStateFlow(loadShowNotification())
+    val showNotification: StateFlow<Boolean> = _showNotification.asStateFlow()
 
     /** Clock sync (NTP-style): offset = macClock - ourClock, from the ping/pong
      * sample with the lowest RTT. Mirrors PhoneReceiver.swift exactly. */
@@ -329,6 +336,16 @@ class PhoneReceiver(context: Context) {
             unadvertise()
             advertise(lastBoundPort)
         }
+    }
+
+    /** Turn the status notification on/off and persist the choice. */
+    fun setShowNotification(show: Boolean) {
+        if (show == _showNotification.value) return
+        _showNotification.value = show
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_SHOW_NOTIFICATION, show)
+            .apply()
     }
 
     /** Best-effort local IPv4 address for manually typing into the Mac app's
@@ -748,6 +765,11 @@ class PhoneReceiver(context: Context) {
     private fun loadServiceName(): String {
         val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return prefs.getString(KEY_SERVICE_NAME, null) ?: Build.MODEL ?: DEFAULT_SERVICE_NAME
+    }
+
+    private fun loadShowNotification(): Boolean {
+        val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getBoolean(KEY_SHOW_NOTIFICATION, true)
     }
 
     private fun nowMs(): Double = System.currentTimeMillis().toDouble()

--- a/app/src/main/java/io/github/josepacelli/opendisplay/service/ReceiverService.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/service/ReceiverService.kt
@@ -84,7 +84,7 @@ class ReceiverService : Service() {
         // Status/connection change -> the notification is the only UI visible
         // while the app isn't in the foreground, so it needs to stay live too.
         serviceScope.launch {
-            combine(receiver.status, receiver.connected) { _, _ -> Unit }
+            combine(receiver.status, receiver.connected, receiver.showNotification) { _, _, _ -> Unit }
                 .collect { updateNotification() }
         }
     }
@@ -140,8 +140,16 @@ class ReceiverService : Service() {
     }
 
     private fun updateNotification() {
-        val manager = getSystemService(NotificationManager::class.java)
-        manager?.notify(NOTIFICATION_ID, buildNotification())
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        // startForeground() always needs *a* notification to satisfy the OS
+        // contract (see onCreate) — turning the setting off just cancels it
+        // right back out from the shade; the foreground service itself is
+        // unaffected either way.
+        if (receiver.showNotification.value) {
+            manager.notify(NOTIFICATION_ID, buildNotification())
+        } else {
+            manager.cancel(NOTIFICATION_ID)
+        }
     }
 
     private fun buildNotification(): Notification {

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -40,6 +41,7 @@ import io.github.josepacelli.opendisplay.net.PhoneReceiver
 fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
     val currentName by receiver.serviceName.collectAsState()
     val connected by receiver.connected.collectAsState()
+    val showNotification by receiver.showNotification.collectAsState()
     var draftName by remember { mutableStateOf(currentName) }
     val addressHint = remember { receiver.localAddressHint() }
     val context = LocalContext.current
@@ -66,6 +68,21 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
                             else R.string.settings_status_connection_waiting,
                         ),
                     )
+                }
+
+                SettingsSection(stringResource(R.string.settings_section_notification)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_notification_show),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f).padding(end = 8.dp),
+                        )
+                        Switch(checked = showNotification, onCheckedChange = { receiver.setShowNotification(it) })
+                    }
                 }
 
                 SettingsSection(stringResource(R.string.settings_section_name)) {

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -19,6 +19,8 @@
     <string name="settings_status_connection">Conexão</string>
     <string name="settings_status_connection_waiting">Aguardando o Mac</string>
     <string name="settings_status_connection_connected">Conectado</string>
+    <string name="settings_section_notification">Notificação</string>
+    <string name="settings_notification_show">Mostrar notificação de status</string>
     <string name="settings_section_name">Nome</string>
     <string name="settings_name_label">Nome anunciado na rede (aparece no menu de conexão do Mac):</string>
     <string name="settings_section_network">Rede</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="settings_status_connection">Connection</string>
     <string name="settings_status_connection_waiting">Waiting for Mac</string>
     <string name="settings_status_connection_connected">Connected</string>
+    <string name="settings_section_notification">Notification</string>
+    <string name="settings_notification_show">Show status notification</string>
     <string name="settings_section_name">Name</string>
     <string name="settings_name_label">Name announced on the network (shown in the Mac\'s connection menu):</string>
     <string name="settings_section_network">Network</string>


### PR DESCRIPTION
## Summary
- New `PhoneReceiver.showNotification` (StateFlow<Boolean>, persisted in the same SharedPreferences as the mDNS service name) + `setShowNotification()`, defaulting to on.
- New "Notificação"/"Notification" section in `SettingsDialog` with a `Switch`, applying immediately (no need to hit Salvar).
- `ReceiverService.updateNotification()` now checks the flag: `notify()` when on, `cancel(NOTIFICATION_ID)` when off. `startForeground()` still always posts a notification on service start (required by the OS foreground-service contract) — if the setting is off, the reactive `combine(status, connected, showNotification)` collector cancels it right back out immediately after.

Fixes #26

## Test plan
- [x] `./gradlew assembleDebug testDebugUnitTest` — build + tests pass
- [x] Installed on tablet: toggle appears in Settings, defaults on; switching off makes the notification disappear from the shade immediately; switching back on brings it right back with current status/version — foreground service itself unaffected either way