### PR TITLE
fix: only keep the screen on while actually connected

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -67,12 +68,6 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         requestNotificationPermissionIfNeeded()
-        // Mirrors iOS's `isIdleTimerDisabled = true`: this app IS the screen
-        // while it's open, so the system's inactivity timeout must not fire
-        // (issue #10). Doesn't block a manual power-button lock — screen
-        // lock/unlock still goes through PhoneReceiver.enterSleep()/wake()
-        // via ReceiverService's SCREEN_OFF/USER_PRESENT receiver.
-        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         val serviceIntent = Intent(this, ReceiverService::class.java)
         startForegroundService(serviceIntent)
@@ -92,6 +87,23 @@ class MainActivity : ComponentActivity() {
                         )
                     }
                 } else {
+                    // Mirrors iOS's `isIdleTimerDisabled = true`: this app IS the
+                    // screen while a Mac is actually mirroring, so the system's
+                    // inactivity timeout must not fire mid-session (issue #10).
+                    // Only while connected, though — idle/waiting should time out
+                    // normally like any other app (issue #28). Doesn't block a
+                    // manual power-button lock either way — screen lock/unlock
+                    // still goes through PhoneReceiver.enterSleep()/wake() via
+                    // ReceiverService's SCREEN_OFF/SCREEN_ON receiver.
+                    LaunchedEffect(receiver) {
+                        receiver.connected.collect { connected ->
+                            if (connected) {
+                                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                            } else {
+                                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                            }
+                        }
+                    }
                     ReceiverScreen(receiver = receiver)
                 }
             }


### PR DESCRIPTION
## Summary
- Reported by @gaeaearth (#28, follow-up on #10): screen stays on even while idle/waiting for the Mac — not just during an active session.
- `FLAG_KEEP_SCREEN_ON` was set once in `onCreate()` and never cleared. `MainActivity` now reacts to `PhoneReceiver.connected` via `LaunchedEffect`, adding the flag only while mirroring and clearing it while idle — matches the original #10/#13 intent (don't let the *display* sleep mid-session) without keeping the screen on for no reason while nothing's happening.

Fixes #28

## Test plan
- [x] `./gradlew assembleDebug testDebugUnitTest` — build + tests pass
- [x] Installed on tablet, confirmed via `adb shell dumpsys window | grep mHoldScreenWindow`:
  - Idle (no Mac): `mHoldScreenWindow=null`
  - Connected (Mac mirroring): `mHoldScreenWindow=Window{... MainActivity}`