### PR TITLE
feat: abstract Link over TCP and USB accessory transports

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,11 +24,22 @@
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden"
             android:screenOrientation="unspecified"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.OpenDisplay">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Launched when a Mac puts this device into AOA mode. The
+                 system's dialog grants accessory permission with the intent,
+                 so no runtime request is needed on this path. -->
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"
+                android:resource="@xml/accessory_filter" />
         </activity>
 
         <service

--- a/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
@@ -7,6 +7,8 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.hardware.usb.UsbAccessory
+import android.hardware.usb.UsbManager
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -46,11 +48,15 @@ class MainActivity : ComponentActivity() {
     private var boundReceiver by mutableStateOf<PhoneReceiver?>(null)
     private var bound = false
 
+    /** Accessory received before the service finished binding; opened once bound. */
+    private var pendingAccessory: UsbAccessory? = null
+
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
             val receiver = (service as? ReceiverService.LocalBinder)?.receiver ?: return
             reportPanelSize(receiver)
             boundReceiver = receiver
+            openPendingAccessory(receiver)
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
@@ -64,10 +70,47 @@ class MainActivity : ComponentActivity() {
     private val notificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
+    /** The cable arrived while the app was already open (see `singleTop`). */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        takeAccessory(intent)
+    }
+
+    private fun takeAccessory(intent: Intent?) {
+        val accessory = intent?.usbAccessory() ?: return
+        pendingAccessory = accessory
+        boundReceiver?.let { openPendingAccessory(it) }
+    }
+
+    private fun openPendingAccessory(receiver: PhoneReceiver) {
+        val accessory = pendingAccessory ?: return
+        pendingAccessory = null
+        val manager = getSystemService(UsbManager::class.java)
+        // Null means the cable left before we got here — a normal race, not an error.
+        val descriptor = manager?.openAccessory(accessory)
+        if (descriptor == null) {
+            Log.warn("USB accessory vanished before it could be opened")
+            return
+        }
+        receiver.attachAccessory(descriptor)
+    }
+
+    private fun Intent.usbAccessory(): UsbAccessory? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelableExtra(UsbManager.EXTRA_ACCESSORY, UsbAccessory::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            getParcelableExtra(UsbManager.EXTRA_ACCESSORY)
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         requestNotificationPermissionIfNeeded()
+
+        // Launch intent may carry the accessory; claimed once the service binds.
+        takeAccessory(intent)
 
         val serviceIntent = Intent(this, ReceiverService::class.java)
         startForegroundService(serviceIntent)

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/Link.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/Link.kt
@@ -1,0 +1,68 @@
+package io.github.josepacelli.opendisplay.net
+
+import android.os.ParcelFileDescriptor
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.Socket
+
+/**
+ * A live peer connection: a byte stream pair plus a way to close it.
+ * Lets [PhoneReceiver] run the same protocol over TCP or a USB accessory fd.
+ */
+interface Link {
+    val input: InputStream
+    val output: OutputStream
+
+    /** Peer identity, for logs and mid-session peer-swap detection. */
+    val label: String
+
+    fun close()
+}
+
+/** WiFi, or loopback via the Mac's `adb forward` override. */
+class SocketLink(private val socket: Socket) : Link {
+    init {
+        // Disable Nagle: touch/scroll are small, latency-sensitive packets.
+        socket.tcpNoDelay = true
+    }
+
+    override val input: InputStream = socket.getInputStream()
+    override val output: OutputStream = socket.getOutputStream()
+    override val label: String = socket.remoteSocketAddress?.toString() ?: "unknown"
+
+    override fun close() {
+        socket.close()
+    }
+}
+
+/**
+ * USB accessory transport (AOA). The streams share one fd via reference
+ * counting, so all three owners must be closed explicitly — otherwise the
+ * GC finalizes them later, possibly after the fd number has been reused.
+ */
+class AccessoryLink(private val descriptor: ParcelFileDescriptor) : Link {
+    override val input: InputStream = FileInputStream(descriptor.fileDescriptor)
+    override val output: OutputStream = FileOutputStream(descriptor.fileDescriptor)
+
+    /** Single accessory host — no address to report. */
+    override val label: String = "usb-accessory"
+
+    override fun close() {
+        // Own try/catch each: one failing must not skip the others.
+        try {
+            input.close()
+        } catch (_: IOException) {
+        }
+        try {
+            output.close()
+        } catch (_: IOException) {
+        }
+        try {
+            descriptor.close()
+        } catch (_: IOException) {
+        }
+    }
+}

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -8,6 +8,7 @@ import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.os.ParcelFileDescriptor
 import android.util.Base64
 import io.github.josepacelli.opendisplay.R
 import io.github.josepacelli.opendisplay.protocol.WireMessage
@@ -139,7 +140,8 @@ class PhoneReceiver(context: Context) {
     private var wifiServerSocket: ServerSocket? = null
     private var advertised = false
 
-    @Volatile private var socket: Socket? = null
+    /** The live connection. Identity check for "still the active session". */
+    @Volatile private var link: Link? = null
 
     @Volatile private var outputStream: OutputStream? = null
 
@@ -320,7 +322,7 @@ class PhoneReceiver(context: Context) {
         devicePixelsWide = widthPx
         devicePixelsHigh = heightPx
         deviceScale = density
-        if (changed && socket?.isConnected == true) {
+        if (changed && link != null) {
             Log.info("panel size changed -> ${widthPx}x$heightPx — resending hello")
             sendHello()
         }
@@ -421,7 +423,7 @@ class PhoneReceiver(context: Context) {
                 while (running.get()) {
                     val client = server.accept()
                     Log.info("new connection from ${client.remoteSocketAddress}")
-                    acceptConnection(client)
+                    acceptConnection(SocketLink(client))
                 }
             } catch (e: IOException) {
                 if (!running.get()) return
@@ -437,17 +439,17 @@ class PhoneReceiver(context: Context) {
         advertise(port)
     }
 
-    private fun acceptConnection(client: Socket) {
-        val previousAddress = socket?.remoteSocketAddress?.toString()
-        val newAddress = client.remoteSocketAddress?.toString()
+    /** Takes over the session with [newLink] — TCP accept or USB attach.
+     * Everything past this point is transport-blind. */
+    private fun acceptConnection(newLink: Link) {
+        val previousLabel = link?.label
         closeConnection() // replace any existing connection, like the Mac replacing its dial
-        if (previousAddress != null && newAddress != null && previousAddress != newAddress) {
-            Log.warn("peer changed mid-session: $previousAddress -> $newAddress")
-            _peerSignal.value = PeerSignal.PeerReplaced(previousAddress, newAddress)
+        if (previousLabel != null && previousLabel != newLink.label) {
+            Log.warn("peer changed mid-session: $previousLabel -> ${newLink.label}")
+            _peerSignal.value = PeerSignal.PeerReplaced(previousLabel, newLink.label)
         }
-        client.tcpNoDelay = true // touch/scroll are tiny packets; Nagle would batch them into lag
-        socket = client
-        outputStream = client.getOutputStream()
+        link = newLink
+        outputStream = newLink.output
         lastDataReceivedAt = System.currentTimeMillis()
         _connected.value = true
         _status.value = appContext.getString(R.string.settings_status_connection_connected)
@@ -455,17 +457,24 @@ class PhoneReceiver(context: Context) {
             Log.warn("sending hello before panel size is known — caller should call setPanelSize() first")
         }
         sendHello()
-        readJob = scope.launch { readLoop(client) }
+        readJob = scope.launch { readLoop(newLink) }
     }
 
-    private fun readLoop(client: Socket) {
+    /** Starts a session from a `USB_ACCESSORY_ATTACHED` intent. No accept
+     * loop for USB — the cable itself is the event. */
+    fun attachAccessory(descriptor: ParcelFileDescriptor) {
+        Log.info("USB accessory attached — starting session over the cable")
+        acceptConnection(AccessoryLink(descriptor))
+    }
+
+    private fun readLoop(current: Link) {
         // Owned entirely by this connection's read coroutine — no sharing
         // across reconnects, so no locking needed around its mutable state.
         val frameDecoder = Framing.FrameDecoder()
-        val input = client.getInputStream()
+        val input = current.input
         val buf = ByteArray(READ_BUFFER_SIZE)
         try {
-            while (running.get() && socket === client) {
+            while (running.get() && link === current) {
                 val n = input.read(buf)
                 if (n < 0) {
                     Log.info("peer closed connection")
@@ -483,26 +492,28 @@ class PhoneReceiver(context: Context) {
         } catch (e: IOException) {
             if (running.get()) Log.info("receive error: ${e.message}")
         } finally {
-            if (socket === client) {
-                socket = null
+            // Guarded: a newer session replacing this one already closed
+            // `current` via closeConnection() — don't race that close.
+            if (link === current) {
+                link = null
                 outputStream = null
                 _connected.value = false
                 _status.value = appContext.getString(R.string.status_listening, lastBoundPort)
-            }
-            try {
-                client.close()
-            } catch (_: IOException) {
+                try {
+                    current.close()
+                } catch (_: IOException) {
+                }
             }
         }
     }
 
     private fun closeConnection() {
-        val client = socket ?: return
-        socket = null
+        val current = link ?: return
+        link = null
         outputStream = null
         _connected.value = false
         try {
-            client.close()
+            current.close()
         } catch (_: IOException) {
         }
     }

--- a/app/src/main/res/xml/accessory_filter.xml
+++ b/app/src/main/res/xml/accessory_filter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Accessory identity this app answers for. Must match the Mac's AOA strings
+  (control request 52) byte-for-byte, or the system dialog never offers this
+  app. Reference values: `aoa_probe.py` (STRINGS).
+-->
+<resources>
+    <usb-accessory
+        manufacturer="OpenDisplay"
+        model="OpenDisplay Receiver"
+        version="1.0" />
+</resources>


### PR DESCRIPTION
This PR abstracts the connection behind a `Link` interface (`SocketLink` for
WiFi/loopback, `AccessoryLink` for a USB accessory) and adds the Android side
of AOA, allowing connection over the cable with no adb, and no developer
options. Companion to peetzweg/opendisplay#225 on the Mac side. Would close #32 .

`accessory_filter.xml` must match the Mac's identity strings (`Mac/USBAccessory.swift`).

Verified with a Galaxy Tab S9 FE+. To reproduce, one needs to clone my mac client fork, build it, run and add the default `defaults write com.peetzweg.opensidecar.mac.debug accessory -bool YES`. Then, with this PR's android app installed, you just plug the cable and a popup will appear offering to connect with OpenDisplay automatically.
