### PR TITLE
fix: clamp cursor sprite dimensions from the peer (SCR-007)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,15 +50,21 @@ SCR-002 through SCR-006 verified still intact, no regressions.
 
 | ID | Title | Severity | CWE | Status |
 |---|---|---|---|---|
-| SCR-007 | Unbounded cursor sprite dimensions (`nw`/`nh`) from peer can crash the Compose layout pass | Medium | CWE-20 | Open — see [#34](https://github.com/josepacelli/opendisplay-android/issues/34) |
+| SCR-007 | Unbounded cursor sprite dimensions (`nw`/`nh`) from peer, no upper-bound check | Low | CWE-20 | Fixed (hardening) — see [#34](https://github.com/josepacelli/opendisplay-android/issues/34) |
 
-SCR-007: `PhoneReceiver.handleCursorImage()` reads `nw`/`nh`/`ax`/`ay` from the untrusted peer's
-`cursorImg` message with no upper-bound check, and `CursorOverlay.kt`'s `CursorSprite` uses them
-directly to size a `Constraints.fixed(...)` measure call — an extreme value (e.g. `"nw": 1e9`) is
-plausibly outside what Compose's `Constraints` can represent, on the UI thread, on every
-recomposition after the message arrives. Distinct from the bitmap-decode bounds check already
-fixed in SCR-002 (that one guards `BitmapFactory`; this one guards the separate normalized-size
-fields used purely for layout). See the issue for full detail and proposed fix.
+SCR-007: `PhoneReceiver.handleCursorImage()` read `nw`/`nh`/`ax`/`ay` from the untrusted peer's
+`cursorImg` message with no upper-bound check, and `CursorOverlay.kt`'s `CursorSprite` used them
+directly to size a `Constraints.fixed(...)` measure call. Initial write-up theorized this could
+crash the app (an extreme value like `"nw": 1e9` seemed likely to exceed what Compose's
+`Constraints` can represent). **Verified against a real crafted-peer exploit attempt** (a raw
+Python TCP client sending `cursor` + a `cursorImg` with `nw=nh=1e9` straight at the unpatched
+build) — **it did not crash**: no fatal exception, same process ID throughout, app kept working
+normally afterward. `Constraints.fixed(a, a)` with a matching min/max apparently doesn't hit the
+same bit-packing ceiling this write-up assumed. Downgraded from the originally-reported Medium
+accordingly. Still fixed as defense-in-depth (`nw`/`nh` now clamped to `0.0..4.0` at ingestion,
+mirroring the SCR-002 bounds-check pattern) — relying on an external library's undocumented
+handling of out-of-range input isn't a real guarantee, even though this specific crash theory
+didn't pan out.
 
 ## What this app deliberately does not have
 

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -625,11 +625,16 @@ class PhoneReceiver(context: Context) {
             Log.warn("bad cursorImg base64", e)
             return
         }
+        // Clamped, not just defaulted: these size a Compose Layout measure call
+        // in CursorOverlay, and an untrusted peer sending something wild like
+        // "nw": 1e9 would push that past what Constraints.fixed() can
+        // represent — a same-LAN crash, no auth needed (SECURITY.md/SCR-007).
+        // 4.0 is generous headroom over anything the real Mac app sends.
         _cursorImage.tryEmit(
             CursorImage(
                 png = png,
-                normalizedWidth = obj.optDouble("nw", 0.0),
-                normalizedHeight = obj.optDouble("nh", 0.0),
+                normalizedWidth = obj.optDouble("nw", 0.0).coerceIn(0.0, 4.0),
+                normalizedHeight = obj.optDouble("nh", 0.0).coerceIn(0.0, 4.0),
                 anchorX = obj.optDouble("ax", 0.0),
                 anchorY = obj.optDouble("ay", 0.0),
             ),


### PR DESCRIPTION
## Summary
- `PhoneReceiver.handleCursorImage()` now clamps `nw`/`nh` (`normalizedWidth`/`normalizedHeight`) to `0.0..4.0` at ingestion, before they reach `CursorOverlay.kt`'s layout-sizing code — same defense-in-depth pattern as SCR-002's bitmap bounds check.
- **Important correction from the original issue**: the write-up theorized this could crash the app via `Constraints.fixed()`. Tested that directly with a real crafted-peer exploit (raw Python TCP client, `cursor` + `cursorImg` with `nw=nh=1e9`) against the unpatched build — **it did not crash**. Severity downgraded from Medium to Low in `SECURITY.md`. Still fixing it as hardening, since relying on an external library's undocumented tolerance for out-of-range input isn't a real guarantee.

Fixes #34

## Test plan
- [x] `./gradlew assembleDebug testDebugUnitTest` — build + tests pass
- [x] Ran the crafted-peer exploit attempt against both the unpatched and patched debug builds on a real tablet — no crash either way, confirming no regression from the clamp and that the original crash theory doesn't reproduce