### PR TITLE
Make the performance overlay optional in Settings

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -102,6 +102,7 @@ class PhoneReceiver(context: Context) {
         private const val KEY_INSTALL_ID = "installID"
         private const val KEY_SERVICE_NAME = "serviceName"
         private const val KEY_SHOW_NOTIFICATION = "showNotification"
+        private const val KEY_SHOW_PERF_HUD = "showPerfHud"
         private const val DEFAULT_SERVICE_NAME = "OpenDisplay Android"
         private const val WATCHDOG_TIMEOUT_MS = 5_000L
         private const val PING_INTERVAL_MS = 2_000L
@@ -198,6 +199,12 @@ class PhoneReceiver(context: Context) {
      * action — see #22) — user-editable in Settings (#26). Defaults on. */
     private val _showNotification = MutableStateFlow(loadShowNotification())
     val showNotification: StateFlow<Boolean> = _showNotification.asStateFlow()
+
+    /** Whether [io.github.josepacelli.opendisplay.ui.ReceiverScreen]'s perf
+     * overlay (fps/latency/RTT) should render — user-editable in Settings
+     * (#36). Defaults on, matching the overlay's prior always-on behavior. */
+    private val _showPerfHud = MutableStateFlow(loadShowPerfHud())
+    val showPerfHud: StateFlow<Boolean> = _showPerfHud.asStateFlow()
 
     /** Clock sync (NTP-style): offset = macClock - ourClock, from the ping/pong
      * sample with the lowest RTT. Mirrors PhoneReceiver.swift exactly. */
@@ -345,6 +352,16 @@ class PhoneReceiver(context: Context) {
         appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit()
             .putBoolean(KEY_SHOW_NOTIFICATION, show)
+            .apply()
+    }
+
+    /** Turn the perf overlay on/off and persist the choice. */
+    fun setShowPerfHud(show: Boolean) {
+        if (show == _showPerfHud.value) return
+        _showPerfHud.value = show
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_SHOW_PERF_HUD, show)
             .apply()
     }
 
@@ -775,6 +792,11 @@ class PhoneReceiver(context: Context) {
     private fun loadShowNotification(): Boolean {
         val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return prefs.getBoolean(KEY_SHOW_NOTIFICATION, true)
+    }
+
+    private fun loadShowPerfHud(): Boolean {
+        val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getBoolean(KEY_SHOW_PERF_HUD, true)
     }
 
     private fun nowMs(): Double = System.currentTimeMillis().toDouble()

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/ReceiverScreen.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/ReceiverScreen.kt
@@ -55,6 +55,7 @@ fun ReceiverScreen(receiver: PhoneReceiver) {
     val status by receiver.status.collectAsState()
     val connected by receiver.connected.collectAsState()
     val peerSignal by receiver.peerSignal.collectAsState()
+    val showPerfHud by receiver.showPerfHud.collectAsState()
     var videoDims by remember { mutableStateOf<VideoDims?>(null) }
     var showSettings by remember { mutableStateOf(false) }
 
@@ -103,7 +104,7 @@ fun ReceiverScreen(receiver: PhoneReceiver) {
             PeerSignalBanner(signal, modifier = Modifier.align(Alignment.TopCenter).padding(top = 32.dp))
         }
 
-        if (connected) {
+        if (connected && showPerfHud) {
             PerfHud(receiver, modifier = Modifier.align(Alignment.TopStart).padding(8.dp))
         }
     }
@@ -179,8 +180,9 @@ private fun InstructionRow(text: String) {
     }
 }
 
-/** Small always-on readout, parity with the iOS receiver's perf overlay —
- * fps / end-to-end latency / control-channel round trip. */
+/** Small readout, parity with the iOS receiver's perf overlay — fps /
+ * end-to-end latency / control-channel round trip. Optional, toggled in
+ * Settings (#36). */
 @Composable
 private fun PerfHud(receiver: PhoneReceiver, modifier: Modifier = Modifier) {
     val perf by receiver.perf.collectAsState()

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
@@ -42,6 +42,7 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
     val currentName by receiver.serviceName.collectAsState()
     val connected by receiver.connected.collectAsState()
     val showNotification by receiver.showNotification.collectAsState()
+    val showPerfHud by receiver.showPerfHud.collectAsState()
     var draftName by remember { mutableStateOf(currentName) }
     val addressHint = remember { receiver.localAddressHint() }
     val context = LocalContext.current
@@ -82,6 +83,21 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
                             modifier = Modifier.weight(1f).padding(end = 8.dp),
                         )
                         Switch(checked = showNotification, onCheckedChange = { receiver.setShowNotification(it) })
+                    }
+                }
+
+                SettingsSection(stringResource(R.string.settings_section_perf_hud)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_perf_hud_show),
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f).padding(end = 8.dp),
+                        )
+                        Switch(checked = showPerfHud, onCheckedChange = { receiver.setShowPerfHud(it) })
                     }
                 }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -21,6 +21,8 @@
     <string name="settings_status_connection_connected">Conectado</string>
     <string name="settings_section_notification">Notificación</string>
     <string name="settings_notification_show">Mostrar notificación</string>
+    <string name="settings_section_perf_hud">Superposición de rendimiento</string>
+    <string name="settings_perf_hud_show">Mostrar superposición de rendimiento</string>
     <string name="settings_section_name">Nombre</string>
     <string name="settings_name_label">Nombre anunciado en la red (aparece en el menú de conexión del Mac):</string>
     <string name="settings_section_network">Red</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -21,6 +21,8 @@
     <string name="settings_status_connection_connected">Conectado</string>
     <string name="settings_section_notification">Notificação</string>
     <string name="settings_notification_show">Mostrar notificação</string>
+    <string name="settings_section_perf_hud">Overlay de desempenho</string>
+    <string name="settings_perf_hud_show">Mostrar overlay de desempenho</string>
     <string name="settings_section_name">Nome</string>
     <string name="settings_name_label">Nome anunciado na rede (aparece no menu de conexão do Mac):</string>
     <string name="settings_section_network">Rede</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -21,6 +21,8 @@
     <string name="settings_status_connection_connected">Ligado</string>
     <string name="settings_section_notification">Notificação</string>
     <string name="settings_notification_show">Mostrar notificação</string>
+    <string name="settings_section_perf_hud">Sobreposição de desempenho</string>
+    <string name="settings_perf_hud_show">Mostrar sobreposição de desempenho</string>
     <string name="settings_section_name">Nome</string>
     <string name="settings_name_label">Nome anunciado na rede (aparece no menu de ligação do Mac):</string>
     <string name="settings_section_network">Rede</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="settings_status_connection_connected">Connected</string>
     <string name="settings_section_notification">Notification</string>
     <string name="settings_notification_show">Show notification</string>
+    <string name="settings_section_perf_hud">Performance overlay</string>
+    <string name="settings_perf_hud_show">Show performance overlay</string>
     <string name="settings_section_name">Name</string>
     <string name="settings_name_label">Name announced on the network (shown in the Mac\'s connection menu):</string>
     <string name="settings_section_network">Network</string>


### PR DESCRIPTION
## Summary

- Adds a switch in `SettingsDialog` to show/hide the fps/latency/RTT performance overlay, which used to always render while connected.
- Persisted via `SharedPreferences` in `PhoneReceiver` (`showPerfHud`), same pattern already used for the notification toggle, defaulting on to match prior behavior.

Fixes #36 — reported by @gaeaearth in a comment on #10.

## Test plan

- [x] `./gradlew assembleDebug testDebugUnitTest` passes
- [ ] Toggle off/on in Settings while connected and confirm the overlay hides/shows