### PR TITLE
fix: don't bind the listener to a cellular interface (SCR-006)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/NetworkInfo.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/NetworkInfo.kt
@@ -1,5 +1,8 @@
 package io.github.josepacelli.opendisplay.net
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import java.net.Inet4Address
 import java.net.NetworkInterface
 
@@ -15,12 +18,16 @@ import java.net.NetworkInterface
  */
 object NetworkInfo {
 
-    fun localIPv4Address(): String? = localIPv4InetAddress()?.hostAddress
+    fun localIPv4Address(context: Context): String? = localIPv4InetAddress(context)?.hostAddress
 
     /** Same lookup as [localIPv4Address], as an [Inet4Address] ready to bind a
      * [java.net.ServerSocket] to directly — so the socket only listens on the
-     * WiFi-reachable interface instead of every interface (see SECURITY.md/SCR-006). */
-    fun localIPv4InetAddress(): Inet4Address? {
+     * WiFi-reachable interface instead of every interface (see SECURITY.md/SCR-006).
+     * `null` when the active network isn't WiFi/Ethernet — e.g. mobile data only,
+     * WiFi off — so the unauthenticated listener never binds onto the cellular
+     * network (see SECURITY.md/SCR-006, issue #39). */
+    fun localIPv4InetAddress(context: Context): Inet4Address? {
+        if (!isActiveNetworkLocal(context)) return null
         return try {
             NetworkInterface.getNetworkInterfaces().asSequence()
                 .filter { it.isUp && !it.isLoopback }
@@ -30,5 +37,16 @@ object NetworkInfo {
         } catch (e: Exception) {
             null
         }
+    }
+
+    /** WiFi or Ethernet, i.e. a LAN — never cellular, which is a WAN uplink with
+     * no business hosting an unauthenticated listener. */
+    private fun isActiveNetworkLocal(context: Context): Boolean {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return false
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
     }
 }

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -235,7 +235,11 @@ class PhoneReceiver(context: Context) {
             listenLoop(port, { InetAddress.getByName("127.0.0.1") }) { loopbackServerSocket = it }
         }
         wifiAcceptJob = scope.launch {
-            listenLoop(port, { NetworkInfo.localIPv4InetAddress(appContext) }) { wifiServerSocket = it }
+            listenLoop(
+                port,
+                { NetworkInfo.localIPv4InetAddress(appContext) },
+                onNoAddress = { _status.value = appContext.getString(R.string.status_no_wifi) },
+            ) { wifiServerSocket = it }
         }
         pingJob = scope.launch { pingLoop() }
         watchdogJob = scope.launch { watchdogLoop() }
@@ -404,11 +408,19 @@ class PhoneReceiver(context: Context) {
 
     /** Shared by the loopback and WiFi listeners — [resolveBindAddress] is re-evaluated on every
      * retry so e.g. the WiFi listener starts working as soon as WiFi comes up, even if it wasn't
-     * available yet when [start] was called. */
-    private fun listenLoop(port: Int, resolveBindAddress: () -> InetAddress?, storeSocket: (ServerSocket) -> Unit) {
+     * available yet when [start] was called. [onNoAddress] fires on every retry with no address
+     * to bind — used by the WiFi listener to keep the status text honest while only the loopback
+     * one is up (e.g. cellular-only, see SECURITY.md/SCR-006). */
+    private fun listenLoop(
+        port: Int,
+        resolveBindAddress: () -> InetAddress?,
+        onNoAddress: () -> Unit = {},
+        storeSocket: (ServerSocket) -> Unit,
+    ) {
         while (running.get()) {
             val bindAddress = resolveBindAddress()
             if (bindAddress == null) {
+                onNoAddress()
                 Thread.sleep(1000)
                 continue
             }

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -4,6 +4,9 @@
 package io.github.josepacelli.opendisplay.net
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiManager
@@ -140,6 +143,13 @@ class PhoneReceiver(context: Context) {
     private var wifiServerSocket: ServerSocket? = null
     private var advertised = false
 
+    /** Forces the WiFi listener to drop and retry as soon as WiFi goes away mid-session —
+     * otherwise it stays blocked in `accept()` on a socket bound to an address that no longer
+     * exists, silently unreachable, until something else happens to close it. */
+    private val connectivityManager =
+        appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+    private var connectivityCallback: ConnectivityManager.NetworkCallback? = null
+
     /** The live connection. Identity check for "still the active session". */
     @Volatile private var link: Link? = null
 
@@ -243,6 +253,7 @@ class PhoneReceiver(context: Context) {
         }
         pingJob = scope.launch { pingLoop() }
         watchdogJob = scope.launch { watchdogLoop() }
+        registerConnectivityWatcher()
     }
 
     fun stop() {
@@ -252,6 +263,8 @@ class PhoneReceiver(context: Context) {
         readJob?.cancel()
         pingJob?.cancel()
         watchdogJob?.cancel()
+        connectivityCallback?.let { connectivityManager?.unregisterNetworkCallback(it) }
+        connectivityCallback = null
         closeConnection()
         closeServerSocket(loopbackServerSocket)
         closeServerSocket(wifiServerSocket)
@@ -269,6 +282,28 @@ class PhoneReceiver(context: Context) {
         } catch (_: IOException) {
             // already gone
         }
+    }
+
+    /** Watches the device's default network so the WiFi listener notices losing WiFi
+     * immediately, instead of only on its next incoming connection attempt. */
+    private fun registerConnectivityWatcher() {
+        val manager = connectivityManager ?: return
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onLost(network: Network) = recheckWifiListener()
+
+            override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) =
+                recheckWifiListener()
+        }
+        manager.registerDefaultNetworkCallback(callback)
+        connectivityCallback = callback
+    }
+
+    /** Closes the WiFi `ServerSocket` if it's bound but WiFi/Ethernet isn't there anymore —
+     * unblocks its `accept()` so [listenLoop] retries and picks up the current reality
+     * (another address, or [R.string.status_no_wifi] if there's nothing to bind to). */
+    private fun recheckWifiListener() {
+        if (NetworkInfo.localIPv4InetAddress(appContext) != null) return
+        closeServerSocket(wifiServerSocket)
     }
 
     /** The device locked — nobody can see the stream. Tells the Mac (so it

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -235,7 +235,7 @@ class PhoneReceiver(context: Context) {
             listenLoop(port, { InetAddress.getByName("127.0.0.1") }) { loopbackServerSocket = it }
         }
         wifiAcceptJob = scope.launch {
-            listenLoop(port, { NetworkInfo.localIPv4InetAddress() }) { wifiServerSocket = it }
+            listenLoop(port, { NetworkInfo.localIPv4InetAddress(appContext) }) { wifiServerSocket = it }
         }
         pingJob = scope.launch { pingLoop() }
         watchdogJob = scope.launch { watchdogLoop() }
@@ -370,7 +370,7 @@ class PhoneReceiver(context: Context) {
     /** Best-effort local IPv4 address for manually typing into the Mac app's
      * host/port override when mDNS discovery doesn't work (some routers and
      * corporate networks block multicast). `null` if nothing usable is found. */
-    fun localAddressHint(): String? = NetworkInfo.localIPv4Address()?.let { "$it:${lastBoundPort}" }
+    fun localAddressHint(): String? = NetworkInfo.localIPv4Address(appContext)?.let { "$it:${lastBoundPort}" }
 
     /** [phase]: "began" | "moved" | "ended" | "cancelled". [x]/[y] normalized
      * 0-1 against the displayed video rect (letterboxing already removed by

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">Iniciando…</string>
     <string name="status_stopped">Detenido</string>
     <string name="status_listening">Escuchando en el puerto :%1$d</string>
-    <string name="status_no_wifi">Sin red WiFi. Activa el WiFi para habilitar la conexión por red.</string>
+    <string name="status_no_wifi">Sin red WiFi. Activa el WiFi o conéctate por cable USB.</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desconectar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,6 +5,7 @@
     <string name="status_starting">Iniciando…</string>
     <string name="status_stopped">Detenido</string>
     <string name="status_listening">Escuchando en el puerto :%1$d</string>
+    <string name="status_no_wifi">Sin red WiFi</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desconectar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">Iniciando…</string>
     <string name="status_stopped">Detenido</string>
     <string name="status_listening">Escuchando en el puerto :%1$d</string>
-    <string name="status_no_wifi">Sin red WiFi</string>
+    <string name="status_no_wifi">Sin red WiFi. Activa el WiFi para habilitar la conexión por red.</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desconectar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -5,6 +5,7 @@
     <string name="status_starting">Iniciando…</string>
     <string name="status_stopped">Parado</string>
     <string name="status_listening">Escutando na porta :%1$d</string>
+    <string name="status_no_wifi">Sem rede WiFi</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desconectar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">Iniciando…</string>
     <string name="status_stopped">Parado</string>
     <string name="status_listening">Escutando na porta :%1$d</string>
-    <string name="status_no_wifi">Sem rede WiFi</string>
+    <string name="status_no_wifi">Sem rede WiFi. Ative o WiFi para habilitar a conexão por rede.</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desconectar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">Iniciando…</string>
     <string name="status_stopped">Parado</string>
     <string name="status_listening">Escutando na porta :%1$d</string>
-    <string name="status_no_wifi">Sem rede WiFi. Ative o WiFi para habilitar a conexão por rede.</string>
+    <string name="status_no_wifi">Sem rede WiFi. Ligue o WiFi ou conecte por cabo USB.</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desconectar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">A iniciar…</string>
     <string name="status_stopped">Parado</string>
     <string name="status_listening">A escutar na porta :%1$d</string>
-    <string name="status_no_wifi">Sem rede WiFi. Ative o WiFi para ativar a ligação por rede.</string>
+    <string name="status_no_wifi">Sem rede WiFi. Ligue o WiFi ou use um cabo USB.</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desligar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">A iniciar…</string>
     <string name="status_stopped">Parado</string>
     <string name="status_listening">A escutar na porta :%1$d</string>
-    <string name="status_no_wifi">Sem rede WiFi</string>
+    <string name="status_no_wifi">Sem rede WiFi. Ative o WiFi para ativar a ligação por rede.</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desligar</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -5,6 +5,7 @@
     <string name="status_starting">A iniciar…</string>
     <string name="status_stopped">Parado</string>
     <string name="status_listening">A escutar na porta :%1$d</string>
+    <string name="status_no_wifi">Sem rede WiFi</string>
 
     <string name="notification_title">OpenDisplay para Android · v%1$s</string>
     <string name="notification_action_disconnect">Desligar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="status_starting">Starting…</string>
     <string name="status_stopped">Stopped</string>
     <string name="status_listening">Listening on :%1$d</string>
+    <string name="status_no_wifi">No WiFi network</string>
 
     <string name="notification_title">OpenDisplay for Android · v%1$s</string>
     <string name="notification_action_disconnect">Disconnect</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">Starting…</string>
     <string name="status_stopped">Stopped</string>
     <string name="status_listening">Listening on :%1$d</string>
-    <string name="status_no_wifi">No WiFi network. Turn on WiFi to enable the network connection.</string>
+    <string name="status_no_wifi">No WiFi network. Turn on WiFi or connect over USB.</string>
 
     <string name="notification_title">OpenDisplay for Android · v%1$s</string>
     <string name="notification_action_disconnect">Disconnect</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="status_starting">Starting…</string>
     <string name="status_stopped">Stopped</string>
     <string name="status_listening">Listening on :%1$d</string>
-    <string name="status_no_wifi">No WiFi network</string>
+    <string name="status_no_wifi">No WiFi network. Turn on WiFi to enable the network connection.</string>
 
     <string name="notification_title">OpenDisplay for Android · v%1$s</string>
     <string name="notification_action_disconnect">Disconnect</string>


### PR DESCRIPTION
## Summary

- The WiFi listener (`NetworkInfo.localIPv4InetAddress()`) picked the first "up, non-loopback" network interface with no regard for its transport — on a device with WiFi off and mobile data on, that's the carrier's `rmnetX` interface, so the unauthenticated video/control socket ended up bound to the LTE network instead of just failing to bind. Now gated behind `ConnectivityManager`: only binds when the active network is WiFi or Ethernet.
- The status text used to say "Listening on :9000" any time the loopback listener (used by the `adb forward` USB path) was up, regardless of whether the WiFi listener actually had anything bound — misleading on a cellular-only device. Now shows "No WiFi network. Turn on WiFi or connect over USB." when there's nothing to bind to.
- If WiFi drops *after* the listener already bound to it, the old code stayed stuck in a blocked `accept()` call on a socket tied to an address that no longer existed — status kept claiming "Listening" indefinitely. Now a `ConnectivityManager.NetworkCallback` on the default network force-closes that socket the moment WiFi goes away, which unblocks `accept()` and lets the existing retry loop pick up the new reality (immediately, not on the next connection attempt).

None of this touches the loopback (`adb forward`) or USB accessory (AOA) transports — both are untouched by network state, by design.

Fixes #39

## Test plan

- [x] `./gradlew assembleDebug testDebugUnitTest` — build and unit tests pass
- [x] Confirmed live on a Galaxy Tab S9 FE+: WiFi off + LTE on, fresh app start → binds to `10.35.243.204:9000` (carrier IP) on `main`, only `127.0.0.1:9000` on this branch — no cellular bind
- [x] Confirmed live: WiFi disabled *while already connected* on this branch → listener drops within ~1s, status flips to "No WiFi network..." (was stuck on "Listening" indefinitely on `main`)
- [x] Confirmed live: WiFi re-enabled → listener and status recover on their own, no restart needed
- [x] Confirmed loopback (`adb forward`) path unaffected by WiFi state in every scenario above