### PR TITLE
fix: request a keyframe when the surface is recreated

### DIFF
--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/VideoSurface.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/VideoSurface.kt
@@ -76,6 +76,12 @@ fun VideoSurface(
                             onSizeChanged = { w, h -> onDimsChanged(VideoDims(w, h)) },
                             onError = { currentReceiver.requestKeyframe() },
                         )
+                        // A brand-new decoder has nothing to render until it sees a keyframe —
+                        // without asking, it just sits black until the Mac's own periodic one,
+                        // up to 60s away (see VideoDecoder's onError doc). Every surface
+                        // recreation (e.g. backgrounding the app and returning) hit exactly
+                        // this with no error involved, so ask immediately instead of waiting.
+                        currentReceiver.requestKeyframe()
                     }
 
                     override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {}


### PR DESCRIPTION
## Summary

- Switching away from the app and back destroys and recreates the `SurfaceView`, which creates a brand-new `MediaCodec` with nothing decoded yet — it just renders black until the next keyframe. `VideoDecoder` already had a proactive fix for this exact symptom on decoder errors (`onError` calls `requestKeyframe()`), but a fresh surface hit the identical problem with no error involved, so it just waited for the Mac's own periodic keyframe — up to 60s away, matching the "black for 1-2 minutes" report. The cursor kept moving throughout because it's a separate overlay, independent of the video decoder.
- `surfaceCreated` now calls `requestKeyframe()` right after creating the decoder, the same call already used in `onError`. `sendControl` already no-ops safely when there's no active connection, so this is safe on cold start too.

Fixes #38

## Test plan

- [x] `./gradlew assembleDebug testDebugUnitTest` — build and unit tests pass
- [x] Confirmed live on a Galaxy Tab S9 FE+ with a real Mac connection: backgrounded the app for ~90s while streaming, switched back — screen recovers in a few seconds (keyframe round-trip: request → Mac re-encodes → decode) instead of the reported 1-2 minutes
- [ ] Not yet confirmed on the reporter's device (Galaxy Note10+, Android 12) — same code path, but flagging since that's the hardware the bug was originally seen on