### PR TITLE
Clean up comments and add KDoc to classes and functions

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,0 +1,124 @@
+# Rationale
+
+Implementation notes that used to live as inline `//` comments in the code — the non-obvious
+*why* behind a specific line or block, moved here to keep the source itself free of mid-function
+comments (see issue #42). KDoc on classes/functions stays in the code; this file is for the
+smaller, line-level decisions that don't belong on a function signature.
+
+Organized by file, in source order.
+
+## MainActivity.kt
+
+- **`notificationPermissionLauncher`** (no-op result handler): if denied, the foreground service
+  still runs fine — only its persistent notification (status/version/disconnect, see #22)
+  silently won't show, same as before this permission request existed.
+- **`openPendingAccessory`**, `manager?.openAccessory(accessory)` returning `null`: means the
+  cable left before we got here — a normal race, not an error.
+- **`onCreate`**, the `takeAccessory(intent)` call before binding: the launch intent may carry the
+  accessory; it's claimed once the service binds.
+- **`onCreate`**, the `FLAG_KEEP_SCREEN_ON` effect: mirrors iOS's `isIdleTimerDisabled = true` —
+  this app IS the screen while a Mac is actually mirroring, so the system's inactivity timeout
+  must not fire mid-session (issue #10). Only while connected, though — idle/waiting should time
+  out normally like any other app (issue #28). Doesn't block a manual power-button lock either
+  way — screen lock/unlock still goes through `PhoneReceiver.enterSleep()`/`wake()` via
+  `ReceiverService`'s `SCREEN_OFF`/`SCREEN_ON` receiver.
+
+## ui/VideoSurface.kt
+
+- **`VideoSurface`**, the frame-collecting `LaunchedEffect`: feeds every decoded frame to
+  whichever decoder is currently attached — `decoder` is read live through the closure each
+  emission, so this one collector survives surface create/destroy cycles.
+- **`surfaceCreated`**, the `requestKeyframe()` call: a brand-new decoder has nothing to render
+  until it sees a keyframe — without asking, it just sits black until the Mac's own periodic one,
+  up to 60s away (see `VideoDecoder`'s `onError` doc in [VideoDecoder.kt](app/src/main/java/io/github/josepacelli/opendisplay/video/VideoDecoder.kt)).
+  Every surface recreation (e.g. backgrounding the app and returning) hit exactly this with no
+  error involved, so ask immediately instead of waiting.
+- **`handleTouchAndScroll`**, `UNDECIDED` state, single pointer under slop: still inside the slop
+  — stay `UNDECIDED` and keep waiting.
+- **`handleTouchAndScroll`**, `UNDECIDED` state, pointer lifted: lifted before crossing slop or
+  gaining a second pointer — a tap.
+
+## ui/ReceiverScreen.kt
+
+- **`ReceiverScreen`**, the `LaunchedEffect(connected)` that closes Settings: the dialog only
+  makes sense while disconnected (see `SettingsDialog`'s doc comment) — if the Mac connects while
+  it happens to be open, the now-actively-rendering `VideoSurface` behind it swallows further
+  mouse input meant for the dialog, leaving it stuck open. Closing it the moment we connect
+  sidesteps that instead of relying on it staying dismissible on top of live video.
+- **`ReceiverScreen`**, the scrim `Box` before `IdleContent`: covers the video box — otherwise the
+  last decoded frame stays visible behind the status text after a disconnect.
+- **`IdleContent`**, the app-icon `Box`: the app icon is an adaptive icon (mipmap XML with
+  separate background/foreground layers) — `painterResource` can't load that directly, so this
+  recreates the round launcher look from its layers.
+- **`IdleContent`**, the status-dot `Row`: this content only renders while disconnected, so the
+  dot mirrors the iOS `IdleView`'s semantics (green = connected) by being orange here by
+  construction, not a value read from `status`.
+
+## video/VideoDecoder.kt
+
+- **`submit`**, `codec ?: return`: no SPS/PPS yet — nothing to feed until the first keyframe.
+- **`reconfigure`**, `KEY_PRIORITY = 0`: realtime priority.
+- **`queueAccessUnit`**, non-blocking `dequeueInputBuffer`: low latency means "latest frame
+  wins" — if the codec is momentarily busy, drop rather than wait, mirroring the Mac encoder's
+  own `pendingEncodes` backpressure. But dropping a NAL isn't free on H.264: P-frames reference
+  the previous decoded frame, so a dropped access unit corrupts every frame after it until a
+  fresh IDR arrives — request one instead of waiting for the Mac's own periodic keyframe (up to
+  60s away).
+- **`drainOutput`**, `releaseOutputBuffer(outIndex, true)`: render ASAP.
+- **`drainOutput`**, the fallback `else -> return`: covers `INFO_TRY_AGAIN_LATER` or the
+  deprecated buffers-changed code.
+
+## net/PhoneReceiver.kt
+
+- **`start`**, the loopback listener's bind address: IPv4 explicitly, not
+  `InetAddress.getLoopbackAddress()` (returns `::1` on this hardware) — the Mac's `adb forward`
+  override dials `127.0.0.1` specifically.
+- **`closeServerSocket`**, the empty catch: the socket was already gone.
+- **`acceptConnection`**, the `closeConnection()` call at the top: replaces any existing
+  connection, like the Mac replacing its dial.
+- **`readLoop`**, the local `FrameDecoder`: owned entirely by this connection's read coroutine —
+  no sharing across reconnects, so no locking is needed around its mutable state.
+- **`readLoop`**, the `finally` guard (`if (link === current)`): a newer session replacing this
+  one already closed `current` via `closeConnection()` — this avoids racing that close.
+- **`handleControlJson`**, the `WireMessage.PING` branch: this is the Mac's OWN liveness ping
+  (separate from ours) — it carries its send-side health (`encDrops`/`netDrops`/`pending`/`capFps`)
+  for its own HUD equivalent. Confirmed live against the real Mac app: it pings every ~2s
+  regardless of whether we ping it. Nothing to reply with here — only *our* ping expects a pong
+  back.
+- **`handleCursorImage`**, clamping `nw`/`nh`: clamped, not just defaulted, because these size a
+  Compose `Layout` measure call in `CursorOverlay`, and an untrusted peer sending something wild
+  like `"nw": 1e9` would push that past what `Constraints.fixed()` can represent — a same-LAN
+  crash, no auth needed (SECURITY.md/SCR-007). `4.0` is generous headroom over anything the real
+  Mac app sends.
+- **`sendControl`**, why it dispatches instead of writing inline: callers include UI-thread touch
+  handlers that must never block on a stalled socket.
+
+## net/Link.kt
+
+- **`SocketLink` init**, `tcpNoDelay = true`: disables Nagle — touch/scroll are small,
+  latency-sensitive packets.
+- **`AccessoryLink.close()`**, the three separate try/catch blocks: one failing must not skip the
+  others.
+
+## service/ReceiverService.kt
+
+- **`screenReceiver`**, `ACTION_SCREEN_ON` (not `ACTION_USER_PRESENT`): Android only sends
+  `USER_PRESENT` when a *secure* keyguard is actually dismissed, which some devices (no secure
+  lock, some OEM power-saving paths — reproduced on a Samsung One UI tablet) never fire on a
+  plain screen-on, leaving the receiver stuck "Stopped" forever (issue #20). `SCREEN_ON` always
+  fires.
+- **`onCreate`**, the `combine(...).collect { updateNotification() }`: status/connection changes
+  need to keep the notification live because it's the only UI visible while the app isn't in the
+  foreground.
+- **`onStartCommand`**, the default `receiver.start()` branch: idempotent — safe to call even if
+  already running.
+- **`registerScreenReceiver`**, `RECEIVER_NOT_EXPORTED`: `SCREEN_OFF`/`SCREEN_ON` are protected
+  system broadcasts — no other app needs to (or should be able to) send us a fake one.
+- **`unregisterScreenReceiverIfNeeded`**, the caught `IllegalArgumentException`: means it was
+  already unregistered.
+- **`updateNotification`**, the `showNotification.value` branch: `startForeground()` always needs
+  *a* notification to satisfy the OS contract (see `onCreate`) — turning the setting off just
+  cancels it right back out from the shade; the foreground service itself is unaffected either
+  way.
+- **`buildNotification`**, the status icon: TODO (fase 9) — dedicated status icon instead of the
+  current system placeholder; needs a real launcher-style small icon.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,8 +8,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <!-- Without this, the foreground service notification is silently hidden
-         on API 33+ — TODO(fase 9): request it at runtime instead of only
-         declaring it, with a rationale UI. -->
+         on API 33+. Requested at runtime too (MainActivity.requestNotificationPermissionIfNeeded) —
+         TODO(fase 9): show a rationale UI before that request instead of asking cold. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application

--- a/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/MainActivity.kt
@@ -51,7 +51,10 @@ class MainActivity : ComponentActivity() {
     /** Accessory received before the service finished binding; opened once bound. */
     private var pendingAccessory: UsbAccessory? = null
 
+    /** Binds this Activity to [ReceiverService], surfacing its [PhoneReceiver] as [boundReceiver]. */
     private val connection = object : ServiceConnection {
+        /** @param name the connected component, unused.
+         * @param service the [ReceiverService.LocalBinder] from the service. */
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
             val receiver = (service as? ReceiverService.LocalBinder)?.receiver ?: return
             reportPanelSize(receiver)
@@ -59,35 +62,38 @@ class MainActivity : ComponentActivity() {
             openPendingAccessory(receiver)
         }
 
+        /** @param name the disconnected component, unused. */
         override fun onServiceDisconnected(name: ComponentName?) {
             boundReceiver = null
         }
     }
 
-    // No-op result handler: if denied, the foreground service still runs fine —
-    // only its persistent notification (status/version/disconnect, see #22)
-    // silently won't show, same as before this permission request existed.
     private val notificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
-    /** The cable arrived while the app was already open (see `singleTop`). */
+    /** The cable arrived while the app was already open (see `singleTop`).
+     * @param intent the new intent, possibly carrying a USB accessory extra. */
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         takeAccessory(intent)
     }
 
+    /** Stashes [intent]'s accessory extra, if any, and opens it right away if the
+     * service is already bound — otherwise [onServiceConnected] picks it up later.
+     * @param intent the launch or new intent to check for a USB accessory extra. */
     private fun takeAccessory(intent: Intent?) {
         val accessory = intent?.usbAccessory() ?: return
         pendingAccessory = accessory
         boundReceiver?.let { openPendingAccessory(it) }
     }
 
+    /** Opens [pendingAccessory] (if still set) and hands its file descriptor to [receiver].
+     * @param receiver the bound session to attach the accessory to. */
     private fun openPendingAccessory(receiver: PhoneReceiver) {
         val accessory = pendingAccessory ?: return
         pendingAccessory = null
         val manager = getSystemService(UsbManager::class.java)
-        // Null means the cable left before we got here — a normal race, not an error.
         val descriptor = manager?.openAccessory(accessory)
         if (descriptor == null) {
             Log.warn("USB accessory vanished before it could be opened")
@@ -96,6 +102,8 @@ class MainActivity : ComponentActivity() {
         receiver.attachAccessory(descriptor)
     }
 
+    /** [UsbManager.EXTRA_ACCESSORY], via the type-safe overload on API 33+.
+     * @return the attached [UsbAccessory], or `null` if this intent doesn't carry one. */
     private fun Intent.usbAccessory(): UsbAccessory? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             getParcelableExtra(UsbManager.EXTRA_ACCESSORY, UsbAccessory::class.java)
@@ -104,12 +112,13 @@ class MainActivity : ComponentActivity() {
             getParcelableExtra(UsbManager.EXTRA_ACCESSORY)
         }
 
+    /** Starts/binds [ReceiverService] and hosts the Compose UI.
+     * @param savedInstanceState unused — this activity keeps no saved state of its own. */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         requestNotificationPermissionIfNeeded()
 
-        // Launch intent may carry the accessory; claimed once the service binds.
         takeAccessory(intent)
 
         val serviceIntent = Intent(this, ReceiverService::class.java)
@@ -130,14 +139,6 @@ class MainActivity : ComponentActivity() {
                         )
                     }
                 } else {
-                    // Mirrors iOS's `isIdleTimerDisabled = true`: this app IS the
-                    // screen while a Mac is actually mirroring, so the system's
-                    // inactivity timeout must not fire mid-session (issue #10).
-                    // Only while connected, though — idle/waiting should time out
-                    // normally like any other app (issue #28). Doesn't block a
-                    // manual power-button lock either way — screen lock/unlock
-                    // still goes through PhoneReceiver.enterSleep()/wake() via
-                    // ReceiverService's SCREEN_OFF/SCREEN_ON receiver.
                     LaunchedEffect(receiver) {
                         receiver.connected.collect { connected ->
                             if (connected) {
@@ -153,12 +154,16 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    /** Rotation/multi-window changes handled in-place (`android:configChanges` in the
+     * manifest) — re-reports the panel size instead of recreating the Activity.
+     * @param newConfig the new device configuration. */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         Log.info("configuration changed — re-reporting panel size")
         boundReceiver?.let { reportPanelSize(it) }
     }
 
+    /** Unbinds from [ReceiverService], if bound — the service itself keeps running. */
     override fun onDestroy() {
         if (bound) {
             unbindService(connection)
@@ -184,6 +189,8 @@ class MainActivity : ComponentActivity() {
      * bounds, which is what matters for multi-window/split-screen on a
      * tablet; the old `DisplayMetrics` path reports the *display*, which is
      * wrong there. Falls back to `DisplayMetrics` below API 30 (minSdk 26).
+     *
+     * @param receiver the session to report this Activity's current panel size to.
      */
     private fun reportPanelSize(receiver: PhoneReceiver) {
         val density = resources.displayMetrics.density.toDouble()

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/AnnexB.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/AnnexB.kt
@@ -17,10 +17,12 @@ object AnnexB {
     private const val OPEN_BRACE = '{'.code.toByte()
 
     /**
-     * True when [payload] is a JSON control message rather than a video frame.
      * Video frames also start with `{` (the telemetry prefix) but always
      * contain NUL bytes (the `00 00 00 01` start codes) — a pure JSON payload
      * never does, even one carrying base64 PNG data.
+     *
+     * @param payload one deframed wire payload.
+     * @return `true` if [payload] is a JSON control message rather than a video frame.
      */
     fun isControlJson(payload: ByteArray): Boolean {
         if (payload.isEmpty() || payload.size >= JSON_SNIFF_MAX_SIZE) return false
@@ -28,7 +30,9 @@ object AnnexB {
         return payload.none { it == 0.toByte() }
     }
 
-    /** One NALU's type nibble (low 5 bits of the header byte). */
+    /** One NALU's type nibble (low 5 bits of the header byte).
+     * @param nalu a single NAL unit, header byte first.
+     * @return the NAL unit type (e.g. `7` = SPS, `8` = PPS, `6` = SEI). */
     fun naluType(nalu: ByteArray): Int = nalu[0].toInt() and 0x1F
 
     data class ParsedFrame(
@@ -51,6 +55,9 @@ object AnnexB {
      * classifies them. Stateless: comparing against the previously-seen
      * SPS/PPS to decide whether the decoder needs rebuilding is the caller's
      * job (it requires session state this parser deliberately doesn't hold).
+     *
+     * @param payload one deframed, non-JSON wire payload (a video frame).
+     * @return the frame split into its telemetry prefix, SPS/PPS (if present), and slice NALUs.
      */
     fun parse(payload: ByteArray): ParsedFrame {
         val nalus = mutableListOf<ByteArray>()
@@ -100,6 +107,9 @@ object AnnexB {
      * Extracts `cap`/`snd` from a telemetry prefix without pulling in a JSON
      * parser — the prefix's shape is fixed (`{"cap":<ms>,"snd":<ms>}`), so a
      * couple of regexes keep this module dependency-free and unit-testable.
+     *
+     * @param prefix the frame's telemetry prefix bytes, or `null` if it had none.
+     * @return the extracted `cap`/`snd` timestamps, each `null` if absent or unparsable.
      */
     fun parseTelemetry(prefix: ByteArray?): Telemetry {
         if (prefix == null) return Telemetry(null, null)

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/Framing.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/Framing.kt
@@ -19,7 +19,9 @@ object Framing {
      * this is comfortably above the largest keyframe this app should ever see. */
     const val MAX_FRAME_SIZE = 16 * 1024 * 1024
 
-    /** Wraps [payload] with its 4-byte big-endian length prefix. */
+    /** Wraps [payload] with its 4-byte big-endian length prefix.
+     * @param payload the message body to frame.
+     * @return a new array: `[4-byte length][payload]`. */
     fun encode(payload: ByteArray): ByteArray {
         val out = ByteArray(HEADER_SIZE + payload.size)
         writeInt32BE(out, 0, payload.size)
@@ -27,6 +29,10 @@ object Framing {
         return out
     }
 
+    /** Reads a 4-byte big-endian integer.
+     * @param buffer the array to read from.
+     * @param offset index of the first (most significant) byte.
+     * @return the decoded integer. */
     fun readInt32BE(buffer: ByteArray, offset: Int): Int {
         return ((buffer[offset].toInt() and 0xFF) shl 24) or
             ((buffer[offset + 1].toInt() and 0xFF) shl 16) or
@@ -34,6 +40,10 @@ object Framing {
             (buffer[offset + 3].toInt() and 0xFF)
     }
 
+    /** Writes a 4-byte big-endian integer.
+     * @param buffer the array to write into.
+     * @param offset index of the first (most significant) byte to write.
+     * @param value the integer to encode. */
     fun writeInt32BE(buffer: ByteArray, offset: Int, value: Int) {
         buffer[offset] = (value ushr 24).toByte()
         buffer[offset + 1] = (value ushr 16).toByte()
@@ -54,7 +64,12 @@ object Framing {
         private var size = 0
 
         /** Feeds [length] bytes from [data] (defaults to the whole array) and
-         * returns every complete frame payload now available, in order. */
+         * returns every complete frame payload now available, in order.
+         * @param data source bytes just read off the wire.
+         * @param length how many bytes of [data] are valid, from index 0.
+         * @return every complete frame payload decoded from the accumulated buffer so far.
+         * @throws IllegalArgumentException if a frame's declared length is negative or exceeds [MAX_FRAME_SIZE].
+         */
         fun feed(data: ByteArray, length: Int = data.size): List<ByteArray> {
             ensureCapacity(size + length)
             System.arraycopy(data, 0, buffer, size, length)
@@ -77,6 +92,8 @@ object Framing {
             return frames
         }
 
+        /** Grows [buffer] (doubling) until it can hold at least [needed] bytes.
+         * @param needed minimum required buffer size, in bytes. */
         private fun ensureCapacity(needed: Int) {
             if (needed <= buffer.size) return
             var newSize = buffer.size * 2

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/Link.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/Link.kt
@@ -13,19 +13,23 @@ import java.net.Socket
  * Lets [PhoneReceiver] run the same protocol over TCP or a USB accessory fd.
  */
 interface Link {
+    /** Bytes coming from the peer. */
     val input: InputStream
+
+    /** Bytes going to the peer. */
     val output: OutputStream
 
     /** Peer identity, for logs and mid-session peer-swap detection. */
     val label: String
 
+    /** Releases every resource this link holds. Safe to call more than once. */
     fun close()
 }
 
-/** WiFi, or loopback via the Mac's `adb forward` override. */
+/** WiFi, or loopback via the Mac's `adb forward` override.
+ * @param socket an already-accepted, connected TCP socket. */
 class SocketLink(private val socket: Socket) : Link {
     init {
-        // Disable Nagle: touch/scroll are small, latency-sensitive packets.
         socket.tcpNoDelay = true
     }
 
@@ -42,6 +46,8 @@ class SocketLink(private val socket: Socket) : Link {
  * USB accessory transport (AOA). The streams share one fd via reference
  * counting, so all three owners must be closed explicitly — otherwise the
  * GC finalizes them later, possibly after the fd number has been reused.
+ *
+ * @param descriptor open file descriptor for the attached USB accessory.
  */
 class AccessoryLink(private val descriptor: ParcelFileDescriptor) : Link {
     override val input: InputStream = FileInputStream(descriptor.fileDescriptor)
@@ -51,7 +57,6 @@ class AccessoryLink(private val descriptor: ParcelFileDescriptor) : Link {
     override val label: String = "usb-accessory"
 
     override fun close() {
-        // Own try/catch each: one failing must not skip the others.
         try {
             input.close()
         } catch (_: IOException) {

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/NetworkInfo.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/NetworkInfo.kt
@@ -18,6 +18,8 @@ import java.net.NetworkInterface
  */
 object NetworkInfo {
 
+    /** @param context used to read connectivity state.
+     * @return this device's local IPv4 address as text, or `null` if none is usable. */
     fun localIPv4Address(context: Context): String? = localIPv4InetAddress(context)?.hostAddress
 
     /** Same lookup as [localIPv4Address], as an [Inet4Address] ready to bind a
@@ -25,7 +27,11 @@ object NetworkInfo {
      * WiFi-reachable interface instead of every interface (see SECURITY.md/SCR-006).
      * `null` when the active network isn't WiFi/Ethernet — e.g. mobile data only,
      * WiFi off — so the unauthenticated listener never binds onto the cellular
-     * network (see SECURITY.md/SCR-006, issue #39). */
+     * network (see SECURITY.md/SCR-006, issue #39).
+     *
+     * @param context used to read connectivity state.
+     * @return the first non-loopback IPv4 address found, or `null` if the active network isn't
+     * WiFi/Ethernet or no such address exists. */
     fun localIPv4InetAddress(context: Context): Inet4Address? {
         if (!isActiveNetworkLocal(context)) return null
         return try {
@@ -40,7 +46,9 @@ object NetworkInfo {
     }
 
     /** WiFi or Ethernet, i.e. a LAN — never cellular, which is a WAN uplink with
-     * no business hosting an unauthenticated listener. */
+     * no business hosting an unauthenticated listener.
+     * @param context used to read connectivity state.
+     * @return `true` if the active network is WiFi or Ethernet. */
     private fun isActiveNetworkLocal(context: Context): Boolean {
         val connectivityManager =
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return false

--- a/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/net/PhoneReceiver.kt
@@ -43,6 +43,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 /** `x`/`y` normalized 0-1 in video space, origin top-left. */
 data class CursorPosition(val x: Double, val y: Double, val visible: Boolean)
 
+/** A decoded cursor sprite, ready for [io.github.josepacelli.opendisplay.ui.CursorOverlay]:
+ * raw PNG bytes plus size/hotspot normalized against the Mac's own display. */
 data class CursorImage(
     val png: ByteArray,
     val normalizedWidth: Double,
@@ -62,6 +64,8 @@ data class VideoFrame(
     val sendMs: Long?,
 )
 
+/** Something the Mac peer told us that the UI needs to surface — version mismatch,
+ * or a different device taking over the session. */
 sealed class PeerSignal {
     /** The connected Mac's protocol is below what we require — issue #132-style gate. */
     data class UpdateMac(val message: String) : PeerSignal()
@@ -116,7 +120,9 @@ class PhoneReceiver(context: Context) {
         /** The `store` field on `updateRequired` comes from an unauthenticated peer (the Mac
          * side of this socket has no auth — see SECURITY.md/SCR-001) — validated here, at the
          * wire boundary, so no future UI code has to remember to sanitize it before turning it
-         * into a clickable link/intent. */
+         * into a clickable link/intent.
+         * @param raw the peer-supplied `store` value, or `null`/blank.
+         * @return [raw] unchanged if it's an `https` URL on [ALLOWED_STORE_HOSTS], else `null`. */
         internal fun sanitizedStoreUrl(raw: String?): String? {
             if (raw.isNullOrBlank()) return null
             val uri = try {
@@ -236,12 +242,12 @@ class PhoneReceiver(context: Context) {
      * first `hello` (sent the moment a Mac connects) carries real dimensions
      * instead of 0x0 — MainActivity does this during setup, before starting
      * the service/receiver.
+     *
+     * @param port TCP port for both the loopback and WiFi listeners.
      */
     fun start(port: Int = DEFAULT_PORT) {
         if (!running.compareAndSet(false, true)) return
         loopbackAcceptJob = scope.launch {
-            // IPv4 explicitly, not InetAddress.getLoopbackAddress() (returns ::1 on this
-            // hardware) — the Mac's `adb forward` override dials 127.0.0.1 specifically.
             listenLoop(port, { InetAddress.getByName("127.0.0.1") }) { loopbackServerSocket = it }
         }
         wifiAcceptJob = scope.launch {
@@ -256,6 +262,7 @@ class PhoneReceiver(context: Context) {
         registerConnectivityWatcher()
     }
 
+    /** Tears down both listeners, the active connection, and mDNS advertisement. */
     fun stop() {
         if (!running.compareAndSet(true, false)) return
         loopbackAcceptJob?.cancel()
@@ -276,11 +283,12 @@ class PhoneReceiver(context: Context) {
         _status.value = appContext.getString(R.string.status_stopped)
     }
 
+    /** Closes [server] if non-null, swallowing an already-closed socket.
+     * @param server the socket to close, or `null` to no-op. */
     private fun closeServerSocket(server: ServerSocket?) {
         try {
             server?.close()
         } catch (_: IOException) {
-            // already gone
         }
     }
 
@@ -325,7 +333,8 @@ class PhoneReceiver(context: Context) {
         }
     }
 
-    /** Screen back on — re-arm listening after [enterSleep]. */
+    /** Screen back on — re-arm listening after [enterSleep].
+     * @param port TCP port to listen on, same default as [start]. */
     fun wake(port: Int = DEFAULT_PORT) {
         start(port)
     }
@@ -355,7 +364,12 @@ class PhoneReceiver(context: Context) {
     /** Real panel size in pixels + density, from the Activity/Compose layer.
      * Re-sends `hello` if we're already connected and the size actually
      * changed (rotation) — mirrors `setOrientation` on iOS, which rebuilds
-     * the Mac's virtual display to match. */
+     * the Mac's virtual display to match.
+     *
+     * @param widthPx panel width in pixels.
+     * @param heightPx panel height in pixels.
+     * @param density this device's display density (pixels per dp).
+     */
     fun setPanelSize(widthPx: Int, heightPx: Int, density: Double) {
         val changed = widthPx != devicePixelsWide || heightPx != devicePixelsHigh
         devicePixelsWide = widthPx
@@ -370,7 +384,8 @@ class PhoneReceiver(context: Context) {
     /** Update the mDNS-advertised name and persist it. If already advertising,
      * re-publishes immediately (NSD has no in-place rename — unregister then
      * register again) so the Mac's WiFi picker picks up the new name without
-     * needing a reconnect. Blank input falls back to the default name. */
+     * needing a reconnect. Blank input falls back to the default name.
+     * @param name desired mDNS service name; blank resolves to [DEFAULT_SERVICE_NAME]. */
     fun setServiceName(name: String) {
         val resolved = name.trim().ifEmpty { DEFAULT_SERVICE_NAME }
         if (resolved == _serviceName.value) return
@@ -386,7 +401,8 @@ class PhoneReceiver(context: Context) {
         }
     }
 
-    /** Turn the status notification on/off and persist the choice. */
+    /** Turn the status notification on/off and persist the choice.
+     * @param show whether [io.github.josepacelli.opendisplay.service.ReceiverService] should show it. */
     fun setShowNotification(show: Boolean) {
         if (show == _showNotification.value) return
         _showNotification.value = show
@@ -396,7 +412,8 @@ class PhoneReceiver(context: Context) {
             .apply()
     }
 
-    /** Turn the perf overlay on/off and persist the choice. */
+    /** Turn the perf overlay on/off and persist the choice.
+     * @param show whether [io.github.josepacelli.opendisplay.ui.ReceiverScreen] should render it. */
     fun setShowPerfHud(show: Boolean) {
         if (show == _showPerfHud.value) return
         _showPerfHud.value = show
@@ -408,12 +425,15 @@ class PhoneReceiver(context: Context) {
 
     /** Best-effort local IPv4 address for manually typing into the Mac app's
      * host/port override when mDNS discovery doesn't work (some routers and
-     * corporate networks block multicast). `null` if nothing usable is found. */
+     * corporate networks block multicast).
+     * @return `"ip:port"`, or `null` if nothing usable is found. */
     fun localAddressHint(): String? = NetworkInfo.localIPv4Address(appContext)?.let { "$it:${lastBoundPort}" }
 
-    /** [phase]: "began" | "moved" | "ended" | "cancelled". [x]/[y] normalized
-     * 0-1 against the displayed video rect (letterboxing already removed by
-     * the caller). */
+    /** Sends a `touch` control message.
+     * @param phase one of `"began"`, `"moved"`, `"ended"`, `"cancelled"`.
+     * @param x normalized 0-1 X against the displayed video rect (letterboxing already removed by the caller).
+     * @param y normalized 0-1 Y against the displayed video rect.
+     */
     fun sendTouch(phase: String, x: Double, y: Double) {
         val message = JSONObject()
             .put("type", WireMessage.TOUCH)
@@ -424,7 +444,10 @@ class PhoneReceiver(context: Context) {
         sendControl(message)
     }
 
-    /** [dx]/[dy] in video pixels, natural-scrolling sign. */
+    /** Sends a `scroll` control message.
+     * @param dx horizontal delta in video pixels, natural-scrolling sign.
+     * @param dy vertical delta in video pixels, natural-scrolling sign.
+     */
     fun sendScroll(dx: Double, dy: Double) {
         sendControl(
             JSONObject()
@@ -439,13 +462,17 @@ class PhoneReceiver(context: Context) {
         sendControl(JSONObject().put("type", WireMessage.KEYFRAME_REQUEST))
     }
 
-    // region Listener + connection lifecycle
-
     /** Shared by the loopback and WiFi listeners — [resolveBindAddress] is re-evaluated on every
      * retry so e.g. the WiFi listener starts working as soon as WiFi comes up, even if it wasn't
      * available yet when [start] was called. [onNoAddress] fires on every retry with no address
      * to bind — used by the WiFi listener to keep the status text honest while only the loopback
-     * one is up (e.g. cellular-only, see SECURITY.md/SCR-006). */
+     * one is up (e.g. cellular-only, see SECURITY.md/SCR-006).
+     *
+     * @param port TCP port to bind.
+     * @param resolveBindAddress returns the address to bind to, or `null` if none is available right now.
+     * @param onNoAddress called on every retry where [resolveBindAddress] returned `null`.
+     * @param storeSocket receives the bound [ServerSocket] so the caller can track/close it later.
+     */
     private fun listenLoop(
         port: Int,
         resolveBindAddress: () -> InetAddress?,
@@ -480,6 +507,9 @@ class PhoneReceiver(context: Context) {
         }
     }
 
+    /** [advertise] should only ever run once per [start]/[stop] cycle, regardless of
+     * how many times [listenLoop] retries.
+     * @param port the bound port to advertise. */
     private fun advertiseOnce(port: Int) {
         if (advertised) return
         advertised = true
@@ -487,10 +517,11 @@ class PhoneReceiver(context: Context) {
     }
 
     /** Takes over the session with [newLink] — TCP accept or USB attach.
-     * Everything past this point is transport-blind. */
+     * Everything past this point is transport-blind.
+     * @param newLink the live connection to adopt as the current session. */
     private fun acceptConnection(newLink: Link) {
         val previousLabel = link?.label
-        closeConnection() // replace any existing connection, like the Mac replacing its dial
+        closeConnection()
         if (previousLabel != null && previousLabel != newLink.label) {
             Log.warn("peer changed mid-session: $previousLabel -> ${newLink.label}")
             _peerSignal.value = PeerSignal.PeerReplaced(previousLabel, newLink.label)
@@ -508,15 +539,17 @@ class PhoneReceiver(context: Context) {
     }
 
     /** Starts a session from a `USB_ACCESSORY_ATTACHED` intent. No accept
-     * loop for USB — the cable itself is the event. */
+     * loop for USB — the cable itself is the event.
+     * @param descriptor open file descriptor for the attached USB accessory. */
     fun attachAccessory(descriptor: ParcelFileDescriptor) {
         Log.info("USB accessory attached — starting session over the cable")
         acceptConnection(AccessoryLink(descriptor))
     }
 
+    /** Drains [current] until it closes, is superseded, or [running] flips off,
+     * deframing and dispatching every wire message along the way.
+     * @param current the connection to read from. */
     private fun readLoop(current: Link) {
-        // Owned entirely by this connection's read coroutine — no sharing
-        // across reconnects, so no locking needed around its mutable state.
         val frameDecoder = Framing.FrameDecoder()
         val input = current.input
         val buf = ByteArray(READ_BUFFER_SIZE)
@@ -539,8 +572,6 @@ class PhoneReceiver(context: Context) {
         } catch (e: IOException) {
             if (running.get()) Log.info("receive error: ${e.message}")
         } finally {
-            // Guarded: a newer session replacing this one already closed
-            // `current` via closeConnection() — don't race that close.
             if (link === current) {
                 link = null
                 outputStream = null
@@ -554,6 +585,7 @@ class PhoneReceiver(context: Context) {
         }
     }
 
+    /** Drops the active [link], if any — idempotent. */
     private fun closeConnection() {
         val current = link ?: return
         link = null
@@ -565,6 +597,9 @@ class PhoneReceiver(context: Context) {
         }
     }
 
+    /** Routes one deframed wire payload to the control-message handler or the
+     * video pipeline, based on [AnnexB.isControlJson].
+     * @param frame one complete deframed wire payload. */
     private fun dispatchFrame(frame: ByteArray) {
         if (AnnexB.isControlJson(frame)) {
             handleControlJson(frame)
@@ -581,7 +616,8 @@ class PhoneReceiver(context: Context) {
 
     /** One-second sliding window: fps + true end-to-end latency (Mac capture
      * to here), using the clock offset from [handlePong]. Simple counters,
-     * not a generic metrics system — there is only ever one peer. */
+     * not a generic metrics system — there is only ever one peer.
+     * @param captureMs the frame's Mac-side capture timestamp, or `null` if the frame carried none. */
     private fun recordPerfSample(captureMs: Long?) {
         framesThisWindow++
         val offset = clockOffsetMs
@@ -604,16 +640,18 @@ class PhoneReceiver(context: Context) {
         perfWindowStartMs = System.currentTimeMillis()
     }
 
+    /** Nearest-rank percentile lookup.
+     * @param sorted values in ascending order.
+     * @param fraction target percentile as a fraction, e.g. `0.5` for the median.
+     * @return the value at that percentile, or `0.0` if [sorted] is empty. */
     private fun percentile(sorted: List<Double>, fraction: Double): Double {
         if (sorted.isEmpty()) return 0.0
         val index = (sorted.size * fraction).toInt().coerceAtMost(sorted.size - 1)
         return sorted[index]
     }
 
-    // endregion
-
-    // region Control messages
-
+    /** Announces this device's identity and panel size — the first message
+     * on any new connection, and again whenever the panel size changes. */
     private fun sendHello() {
         val message = JSONObject()
             .put("type", WireMessage.HELLO)
@@ -627,6 +665,8 @@ class PhoneReceiver(context: Context) {
         Log.info("hello sent ($devicePixelsWide x $devicePixelsHigh @${deviceScale}x)")
     }
 
+    /** Parses one JSON control payload and dispatches it by its `type` field.
+     * @param payload raw UTF-8 JSON bytes of one control message. */
     private fun handleControlJson(payload: ByteArray) {
         val obj = try {
             JSONObject(String(payload, Charsets.UTF_8))
@@ -635,13 +675,7 @@ class PhoneReceiver(context: Context) {
             return
         }
         when (val type = obj.optString("type")) {
-            WireMessage.PING -> {
-                // The Mac's OWN liveness ping (separate from ours) — carries its
-                // send-side health (encDrops/netDrops/pending/capFps) for its own
-                // HUD equivalent. Confirmed live against the real Mac app: it
-                // pings every ~2s regardless of whether we ping it. Nothing to
-                // reply with — only *our* ping expects a pong back.
-            }
+            WireMessage.PING -> {}
 
             WireMessage.WELCOME -> {
                 val macVersion = obj.optInt("pv", WireProtocol.ASSUMED_WHEN_ABSENT)
@@ -677,6 +711,8 @@ class PhoneReceiver(context: Context) {
         }
     }
 
+    /** Turns one `pong` reply into an RTT/clock-offset sample — see [offsetSamples].
+     * @param obj the parsed `pong` message, expected to carry `t` (our send time) and `mt` (Mac's clock). */
     private fun handlePong(obj: JSONObject) {
         if (!obj.has("t") || !obj.has("mt")) return
         val t1 = obj.optDouble("t", Double.NaN)
@@ -692,6 +728,8 @@ class PhoneReceiver(context: Context) {
         clockOffsetMs = offsetSamples.minByOrNull { it.rtt }?.offset
     }
 
+    /** Decodes a `cursorImg` control message into a [CursorImage] for the overlay.
+     * @param obj the parsed `cursorImg` message (`png` base64, `nw`/`nh`/`ax`/`ay`). */
     private fun handleCursorImage(obj: JSONObject) {
         val b64 = obj.optString("png").takeIf { it.isNotEmpty() } ?: return
         val png = try {
@@ -700,11 +738,6 @@ class PhoneReceiver(context: Context) {
             Log.warn("bad cursorImg base64", e)
             return
         }
-        // Clamped, not just defaulted: these size a Compose Layout measure call
-        // in CursorOverlay, and an untrusted peer sending something wild like
-        // "nw": 1e9 would push that past what Constraints.fixed() can
-        // represent — a same-LAN crash, no auth needed (SECURITY.md/SCR-007).
-        // 4.0 is generous headroom over anything the real Mac app sends.
         _cursorImage.tryEmit(
             CursorImage(
                 png = png,
@@ -716,16 +749,17 @@ class PhoneReceiver(context: Context) {
         )
     }
 
+    /** Frames and writes [json] to the peer on [Dispatchers.IO], asynchronously.
+     * @param json the control message to send. */
     private fun sendControl(json: JSONObject) {
-        // Dispatched, not written inline: callers include UI-thread touch
-        // handlers that must never block on a stalled socket.
         scope.launch(Dispatchers.IO) { sendControlBlocking(json) }
     }
 
     /** Same wire write as [sendControl], but synchronous — for the rare
      * caller (enterSleep/shutDown) that must guarantee the write happens
      * before it proceeds to tear the connection down right after. Must be
-     * called from a background thread/coroutine, never the main thread. */
+     * called from a background thread/coroutine, never the main thread.
+     * @param json the control message to send. */
     private fun sendControlBlocking(json: JSONObject) {
         val out = outputStream ?: return
         val framed = Framing.encode(json.toString().toByteArray(Charsets.UTF_8))
@@ -739,10 +773,8 @@ class PhoneReceiver(context: Context) {
         }
     }
 
-    // endregion
-
-    // region Liveness
-
+    /** Sends our own `ping` every [PING_INTERVAL_MS] while connected, so [handlePong]
+     * has a steady stream of RTT/clock-offset samples. */
     private suspend fun pingLoop() {
         while (running.get()) {
             delay(PING_INTERVAL_MS)
@@ -752,6 +784,8 @@ class PhoneReceiver(context: Context) {
         }
     }
 
+    /** Drops the connection if nothing arrived from the peer in [WATCHDOG_TIMEOUT_MS] —
+     * catches a dead link the OS hasn't noticed yet. */
     private suspend fun watchdogLoop() {
         while (running.get()) {
             delay(2000)
@@ -762,10 +796,8 @@ class PhoneReceiver(context: Context) {
         }
     }
 
-    // endregion
-
-    // region NSD (mDNS) discovery
-
+    /** Registers this device's mDNS service so the Mac's WiFi picker can find it.
+     * @param boundPort the port the listener is actually bound to. */
     private fun advertise(boundPort: Int) {
         lastBoundPort = boundPort
         val manager = appContext.getSystemService(Context.NSD_SERVICE) as? NsdManager
@@ -807,6 +839,8 @@ class PhoneReceiver(context: Context) {
         acquireMulticastLock()
     }
 
+    /** mDNS is multicast — without this lock some devices silently drop
+     * incoming multicast packets while the WiFi radio is asleep. */
     private fun acquireMulticastLock() {
         val wifi = appContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return
         try {
@@ -819,6 +853,7 @@ class PhoneReceiver(context: Context) {
         }
     }
 
+    /** Withdraws the mDNS service registration and releases the multicast lock. */
     private fun unadvertise() {
         registrationListener?.let { listener ->
             try {
@@ -832,8 +867,8 @@ class PhoneReceiver(context: Context) {
         multicastLock = null
     }
 
-    // endregion
-
+    /** Persistent per-install UUID, generated once and reused across app restarts.
+     * @return the stored install ID, creating and persisting one first if none exists yet. */
     private fun loadOrCreateInstallId(): String {
         val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         prefs.getString(KEY_INSTALL_ID, null)?.let { return it }
@@ -842,20 +877,24 @@ class PhoneReceiver(context: Context) {
         return fresh
     }
 
+    /** @return the persisted mDNS service name, or [Build.MODEL]/[DEFAULT_SERVICE_NAME] on first run. */
     private fun loadServiceName(): String {
         val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return prefs.getString(KEY_SERVICE_NAME, null) ?: Build.MODEL ?: DEFAULT_SERVICE_NAME
     }
 
+    /** @return the persisted status-notification preference, defaulting to `true`. */
     private fun loadShowNotification(): Boolean {
         val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return prefs.getBoolean(KEY_SHOW_NOTIFICATION, true)
     }
 
+    /** @return the persisted perf-overlay preference, defaulting to `true`. */
     private fun loadShowPerfHud(): Boolean {
         val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         return prefs.getBoolean(KEY_SHOW_PERF_HUD, true)
     }
 
+    /** @return the current wall-clock time in milliseconds, as a [Double] (wire messages use floats). */
     private fun nowMs(): Double = System.currentTimeMillis().toDouble()
 }

--- a/app/src/main/java/io/github/josepacelli/opendisplay/service/ReceiverService.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/service/ReceiverService.kt
@@ -54,6 +54,8 @@ class ReceiverService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private var screenReceiverRegistered = false
+
+    /** Suspends/resumes the receiver in step with the device's screen state. */
     private val screenReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             when (intent.action) {
@@ -62,12 +64,6 @@ class ReceiverService : Service() {
                     receiver.enterSleep()
                 }
                 Intent.ACTION_SCREEN_ON -> {
-                    // Not ACTION_USER_PRESENT: Android only sends that when a
-                    // *secure* keyguard is actually dismissed, which some
-                    // devices (no secure lock, some OEM power-saving paths —
-                    // reproduced on a Samsung One UI tablet) never fire on a
-                    // plain screen-on, leaving the receiver stuck "Stopped"
-                    // forever (issue #20). SCREEN_ON always fires.
                     Log.info("screen on — waking")
                     receiver.wake()
                     updateNotification()
@@ -76,28 +72,34 @@ class ReceiverService : Service() {
         }
     }
 
+    /** Creates the single [PhoneReceiver] for the process and enters the foreground. */
     override fun onCreate() {
         super.onCreate()
         receiver = PhoneReceiver(applicationContext)
         startForeground(NOTIFICATION_ID, buildNotification())
         registerScreenReceiver()
-        // Status/connection change -> the notification is the only UI visible
-        // while the app isn't in the foreground, so it needs to stay live too.
         serviceScope.launch {
             combine(receiver.status, receiver.connected, receiver.showNotification) { _, _, _ -> Unit }
                 .collect { updateNotification() }
         }
     }
 
+    /** Starts (or restarts) listening, or handles the notification's Disconnect action.
+     * @param intent carries [ACTION_DISCONNECT] when launched from the notification action.
+     * @param flags standard `Service.onStartCommand` flags, unused.
+     * @param startId standard `Service.onStartCommand` start id, unused.
+     * @return [Service.START_STICKY] so Android restarts this service if it's killed. */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_DISCONNECT) {
             receiver.disconnect()
         } else {
-            receiver.start() // idempotent — safe if already running
+            receiver.start()
         }
         return START_STICKY
     }
 
+    /** @param intent the binding intent, unused — every caller gets the same [PhoneReceiver].
+     * @return a [LocalBinder] exposing this service's [PhoneReceiver]. */
     override fun onBind(intent: Intent?): IBinder = binder
 
     /** User swiped the app away from recents — a deliberate close, not a
@@ -110,6 +112,7 @@ class ReceiverService : Service() {
         super.onTaskRemoved(rootIntent)
     }
 
+    /** Tells the Mac we're closing and tears down the receiver and its coroutine scope. */
     override fun onDestroy() {
         unregisterScreenReceiverIfNeeded()
         receiver.shutDown()
@@ -117,34 +120,30 @@ class ReceiverService : Service() {
         super.onDestroy()
     }
 
+    /** Registers [screenReceiver] for `SCREEN_OFF`/`SCREEN_ON`, once. */
     private fun registerScreenReceiver() {
         if (screenReceiverRegistered) return
         val filter = IntentFilter().apply {
             addAction(Intent.ACTION_SCREEN_OFF)
             addAction(Intent.ACTION_SCREEN_ON)
         }
-        // NOT_EXPORTED: these are protected system broadcasts, no other app
-        // needs to (or should be able to) send us a fake SCREEN_OFF/USER_PRESENT.
         ContextCompat.registerReceiver(this, screenReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
         screenReceiverRegistered = true
     }
 
+    /** Unregisters [screenReceiver], if currently registered — safe to call more than once. */
     private fun unregisterScreenReceiverIfNeeded() {
         if (!screenReceiverRegistered) return
         try {
             unregisterReceiver(screenReceiver)
         } catch (_: IllegalArgumentException) {
-            // already unregistered
         }
         screenReceiverRegistered = false
     }
 
+    /** Refreshes (or cancels, per [PhoneReceiver.showNotification]) the status notification. */
     private fun updateNotification() {
         val manager = getSystemService(NotificationManager::class.java) ?: return
-        // startForeground() always needs *a* notification to satisfy the OS
-        // contract (see onCreate) — turning the setting off just cancels it
-        // right back out from the shade; the foreground service itself is
-        // unaffected either way.
         if (receiver.showNotification.value) {
             manager.notify(NOTIFICATION_ID, buildNotification())
         } else {
@@ -152,6 +151,8 @@ class ReceiverService : Service() {
         }
     }
 
+    /** @return the foreground-service notification: status text, tap-to-open, and a
+     * Disconnect action while connected. */
     private fun buildNotification(): Notification {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val manager = getSystemService(NotificationManager::class.java)
@@ -169,8 +170,6 @@ class ReceiverService : Service() {
             openIntent,
             PendingIntent.FLAG_IMMUTABLE,
         )
-        // TODO(fase 9): dedicated status icon instead of this system
-        // placeholder — needs a real launcher-style small icon.
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.notification_title, versionName() ?: "?"))
             .setContentText(receiver.status.value)
@@ -193,6 +192,7 @@ class ReceiverService : Service() {
         return builder.build()
     }
 
+    /** @return this build's version name, or `null` if it can't be read. */
     @Suppress("DEPRECATION")
     private fun versionName(): String? =
         runCatching { packageManager.getPackageInfo(packageName, 0).versionName }.getOrNull()

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/CursorOverlay.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/CursorOverlay.kt
@@ -36,6 +36,9 @@ import kotlinx.coroutines.flow.collectLatest
  * `fillMaxSize` siblings inside the same aspect-ratio box in
  * `ReceiverScreen` — a plain dot until a `cursorImg` sprite arrives, then the
  * real sprite, anchored at its reported hotspot.
+ *
+ * @param receiver source of cursor position/sprite updates.
+ * @param modifier applied to the drawing surface.
  */
 @Composable
 fun CursorOverlay(receiver: PhoneReceiver, modifier: Modifier = Modifier) {
@@ -70,6 +73,9 @@ fun CursorOverlay(receiver: PhoneReceiver, modifier: Modifier = Modifier) {
  * leaves real headroom while still rejecting a decompression-bomb-style claim. */
 private const val MAX_SPRITE_DIMENSION_PX = 1024
 
+/** Bounds-checks and decodes [image]'s PNG bytes into a bitmap ready to draw.
+ * @param image the peer-supplied cursor sprite to decode.
+ * @return the decoded sprite, or `null` if it's oversized or not a valid PNG. */
 private fun decodeSprite(image: CursorImage): DecodedSprite? {
     val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
     BitmapFactory.decodeByteArray(image.png, 0, image.png.size, bounds)
@@ -101,6 +107,10 @@ private data class DecodedSprite(
  * size depends on the parent's own measured size (`normalizedWidth`/`Height`
  * are normalized against the Mac's display, per the wire protocol), which
  * isn't known until measurement — a plain offset modifier can't express that.
+ *
+ * @param pos normalized cursor position within the parent box.
+ * @param sprite the decoded sprite to draw.
+ * @param modifier applied to the layout.
  */
 @Composable
 private fun CursorSprite(pos: CursorPosition, sprite: DecodedSprite, modifier: Modifier) {

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/ReceiverScreen.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/ReceiverScreen.kt
@@ -49,6 +49,8 @@ import io.github.josepacelli.opendisplay.net.PhoneReceiver
  * draws every app edge-to-edge by default — without this padding, our
  * touch-capturing surface silently ate the whole screen, including the
  * system bars, so there was no way back to Android itself once connected.
+ *
+ * @param receiver the session this screen renders and forwards input to.
  */
 @Composable
 fun ReceiverScreen(receiver: PhoneReceiver) {
@@ -59,12 +61,6 @@ fun ReceiverScreen(receiver: PhoneReceiver) {
     var videoDims by remember { mutableStateOf<VideoDims?>(null) }
     var showSettings by remember { mutableStateOf(false) }
 
-    // The dialog only makes sense while disconnected (see SettingsDialog's
-    // doc comment) — if the Mac connects while it happens to be open, the
-    // now-actively-rendering VideoSurface behind it swallows further mouse
-    // input meant for the dialog, leaving it stuck open. Closing it the
-    // moment we connect sidesteps that instead of relying on it staying
-    // dismissible on top of live video.
     LaunchedEffect(connected) {
         if (connected) showSettings = false
     }
@@ -94,8 +90,6 @@ fun ReceiverScreen(receiver: PhoneReceiver) {
         }
 
         if (!connected) {
-            // Scrim over the video box — otherwise the last decoded frame
-            // stays visible behind the status text after a disconnect.
             Box(modifier = Modifier.fillMaxSize().background(Color.Black))
             IdleContent(status = status, onSettingsClick = { showSettings = true })
         }
@@ -118,6 +112,9 @@ fun ReceiverScreen(receiver: PhoneReceiver) {
  * No-Mac-connected state — mirrors the upstream iOS client's `IdleView`:
  * logo, title, a colored status dot, a short instructions card and a
  * proper Settings button, instead of a bare status line.
+ *
+ * @param status human-readable listener status to show next to the dot.
+ * @param onSettingsClick called when the Settings button is tapped.
  */
 @Composable
 private fun IdleContent(status: String, onSettingsClick: () -> Unit) {
@@ -125,9 +122,6 @@ private fun IdleContent(status: String, onSettingsClick: () -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.widthIn(max = 420.dp).padding(24.dp),
     ) {
-        // The app icon is an adaptive icon (mipmap XML with separate
-        // background/foreground layers) — painterResource can't load that
-        // directly, so recreate the round launcher look from its layers.
         Box(
             modifier = Modifier.size(96.dp).clip(CircleShape).background(Color.White),
             contentAlignment = Alignment.Center,
@@ -146,9 +140,6 @@ private fun IdleContent(status: String, onSettingsClick: () -> Unit) {
         )
         Spacer(modifier = Modifier.height(6.dp))
         Row(verticalAlignment = Alignment.CenterVertically) {
-            // This content only renders while disconnected — the dot mirrors
-            // the iOS IdleView's semantics (green = connected), so it's
-            // orange here by construction, not a value read from `status`.
             Box(modifier = Modifier.size(8.dp).background(Color(0xFFFFA000), CircleShape))
             Spacer(modifier = Modifier.width(8.dp))
             Text(text = status, color = Color.White.copy(alpha = 0.8f), style = MaterialTheme.typography.bodyMedium)
@@ -171,6 +162,8 @@ private fun IdleContent(status: String, onSettingsClick: () -> Unit) {
     }
 }
 
+/** One bulleted line inside [IdleContent]'s instructions card.
+ * @param text the instruction text to show. */
 @Composable
 private fun InstructionRow(text: String) {
     Row(verticalAlignment = Alignment.Top) {
@@ -182,7 +175,9 @@ private fun InstructionRow(text: String) {
 
 /** Small readout, parity with the iOS receiver's perf overlay — fps /
  * end-to-end latency / control-channel round trip. Optional, toggled in
- * Settings (#36). */
+ * Settings (#36).
+ * @param receiver source of the live [io.github.josepacelli.opendisplay.net.PerfStats].
+ * @param modifier applied to the readout's background/padding. */
 @Composable
 private fun PerfHud(receiver: PhoneReceiver, modifier: Modifier = Modifier) {
     val perf by receiver.perf.collectAsState()
@@ -196,6 +191,10 @@ private fun PerfHud(receiver: PhoneReceiver, modifier: Modifier = Modifier) {
     )
 }
 
+/** Red banner for whatever [PeerSignal] the Mac last sent — update warnings or a
+ * peer-replaced notice.
+ * @param signal the signal to render.
+ * @param modifier applied to the banner surface. */
 @Composable
 private fun PeerSignalBanner(signal: PeerSignal, modifier: Modifier = Modifier) {
     val message = when (signal) {

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/SettingsDialog.kt
@@ -36,6 +36,9 @@ import io.github.josepacelli.opendisplay.net.PhoneReceiver
  * renderer / Local Network permission items — this app only ever listens
  * on plain TCP, so there's nothing OS-specific to toggle. Shown only while
  * disconnected; once video is flowing this app has no chrome at all.
+ *
+ * @param receiver the session whose settings are shown/edited.
+ * @param onDismiss called when the dialog should close (Cancel, Save, or scrim tap).
  */
 @Composable
 fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
@@ -170,6 +173,10 @@ fun SettingsDialog(receiver: PhoneReceiver, onDismiss: () -> Unit) {
     )
 }
 
+/** A titled group of rows inside [SettingsDialog], with an optional trailing divider.
+ * @param title section heading.
+ * @param showDivider whether to draw a divider below the section.
+ * @param content the section's rows. */
 @Composable
 private fun SettingsSection(title: String, showDivider: Boolean = true, content: @Composable () -> Unit) {
     Column(modifier = Modifier.padding(top = 12.dp)) {
@@ -183,6 +190,9 @@ private fun SettingsSection(title: String, showDivider: Boolean = true, content:
     }
 }
 
+/** A label/value pair on one row, right-aligned value.
+ * @param label the row's left-aligned label.
+ * @param value the row's right-aligned value. */
 @Composable
 private fun LabeledRow(label: String, value: String) {
     Row(

--- a/app/src/main/java/io/github/josepacelli/opendisplay/ui/VideoSurface.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/ui/VideoSurface.kt
@@ -36,6 +36,11 @@ data class VideoDims(val width: Int, val height: Int)
  * width/height first guessed from this device's own announced panel size,
  * then refined via [onVideoDimsChanged]) so it, and the cursor overlay next
  * to it, both fill that same letterboxed/pillarboxed rect.
+ *
+ * @param receiver source of decoded video frames and touch/scroll sink.
+ * @param videoDims current known decoded frame size, or `null` before the first one arrives.
+ * @param onVideoDimsChanged called when the decoder reports a real (possibly new) output size.
+ * @param modifier applied to the underlying `SurfaceView`.
  */
 @Composable
 fun VideoSurface(
@@ -49,9 +54,6 @@ fun VideoSurface(
     val currentDims by rememberUpdatedState(videoDims)
     val onDimsChanged by rememberUpdatedState(onVideoDimsChanged)
 
-    // Feeds every decoded frame to whichever decoder is currently attached —
-    // `decoder` is read live through the closure each emission, so this one
-    // collector survives surface create/destroy cycles.
     LaunchedEffect(receiver) {
         receiver.videoFrames.collect { frame -> decoder?.submit(frame) }
     }
@@ -76,11 +78,6 @@ fun VideoSurface(
                             onSizeChanged = { w, h -> onDimsChanged(VideoDims(w, h)) },
                             onError = { currentReceiver.requestKeyframe() },
                         )
-                        // A brand-new decoder has nothing to render until it sees a keyframe —
-                        // without asking, it just sits black until the Mac's own periodic one,
-                        // up to 60s away (see VideoDecoder's onError doc). Every surface
-                        // recreation (e.g. backgrounding the app and returning) hit exactly
-                        // this with no error involved, so ask immediately instead of waiting.
                         currentReceiver.requestKeyframe()
                     }
 
@@ -108,6 +105,9 @@ fun VideoSurface(
  * ever sending `began` for what turns out to be a two-finger scroll, which
  * would otherwise leave the Mac's mouse button stuck down (see
  * `Mac/InputInjector.swift`: `began` maps straight to `mouseDown`).
+ *
+ * @param getVideoDims current decoded video size, needed to convert scroll deltas to video pixels.
+ * @param receiver where resulting `touch`/`scroll` messages are sent.
  */
 private suspend fun PointerInputScope.handleTouchAndScroll(
     getVideoDims: () -> VideoDims?,
@@ -143,11 +143,9 @@ private suspend fun PointerInputScope.handleTouchAndScroll(
                             receiver.sendTouch("moved", mx, my)
                             lastCentroid = pressed[0].position
                         }
-                        // else: still inside the slop — stay UNDECIDED and keep waiting.
                     }
 
                     else -> {
-                        // Lifted before crossing slop or gaining a second pointer: a tap.
                         val (nx, ny) = normalized(startPos.x, startPos.y)
                         receiver.sendTouch("began", nx, ny)
                         receiver.sendTouch("ended", nx, ny)
@@ -186,8 +184,13 @@ private suspend fun PointerInputScope.handleTouchAndScroll(
     }
 }
 
+/** Which wire message a gesture in progress will become, once enough pointers/movement
+ * make that clear — see [handleTouchAndScroll]. */
 private enum class GestureMode { UNDECIDED, TOUCH, SCROLL }
 
+/** Average position of every active pointer, for multi-finger scroll.
+ * @param changes the currently active pointers.
+ * @return their centroid, in local coordinates. */
 private fun centroidOf(changes: List<PointerInputChange>): Offset {
     var x = 0f
     var y = 0f

--- a/app/src/main/java/io/github/josepacelli/opendisplay/video/VideoDecoder.kt
+++ b/app/src/main/java/io/github/josepacelli/opendisplay/video/VideoDecoder.kt
@@ -27,17 +27,21 @@ import java.nio.ByteBuffer
  *
  * Not thread-safe — feed it from a single thread/coroutine (the same one
  * draining [io.github.josepacelli.opendisplay.net.PhoneReceiver.videoFrames]).
+ *
+ * @param surface where decoded frames are rendered.
+ * @param expectedWidth seed width in pixels, used until the real size arrives.
+ * @param expectedHeight seed height in pixels, used until the real size arrives.
+ * @param onSizeChanged called once the codec reports its real output size.
+ * @param onError called (at most once a second) when the codec needs a fresh keyframe
+ * (error or desync) — mirrors the iOS receiver's `requestKeyframeIfNeeded`. Without this,
+ * a decoder error would otherwise leave the picture frozen until the Mac's own periodic
+ * keyframe, up to 60s away (see `Mac/MacSender.swift`).
  */
 class VideoDecoder(
     private val surface: Surface,
     private var expectedWidth: Int,
     private var expectedHeight: Int,
     private val onSizeChanged: (width: Int, height: Int) -> Unit = { _, _ -> },
-    /** Called (at most once a second) when the codec errors out, so the
-     * caller can ask the Mac for a fresh keyframe — mirrors the iOS
-     * receiver's `requestKeyframeIfNeeded`. Without this, a decoder error
-     * would otherwise leave the picture frozen until the Mac's own periodic
-     * keyframe, up to 60s away (see `Mac/MacSender.swift`). */
     private val onError: () -> Unit = {},
 ) {
     private var codec: MediaCodec? = null
@@ -48,12 +52,17 @@ class VideoDecoder(
 
     /** Update the seed size (e.g. after a rotation) before the next SPS/PPS
      * change triggers a reconfigure. Does not itself force a reconfigure —
-     * the wire protocol always follows a rotation with new SPS/PPS anyway. */
+     * the wire protocol always follows a rotation with new SPS/PPS anyway.
+     * @param width new seed width in pixels.
+     * @param height new seed height in pixels.
+     */
     fun updateExpectedSize(width: Int, height: Int) {
         expectedWidth = width
         expectedHeight = height
     }
 
+    /** Feeds one wire [VideoFrame] to the decoder, reconfiguring first if it carries new SPS/PPS.
+     * @param frame the frame to decode. */
     fun submit(frame: VideoFrame) {
         var headersChanged = false
         frame.sps?.let {
@@ -70,10 +79,11 @@ class VideoDecoder(
         }
         if (headersChanged) reconfigure()
         if (frame.vclNalus.isEmpty()) return
-        val mediaCodec = codec ?: return // no SPS/PPS yet — nothing to feed until the first keyframe
+        val mediaCodec = codec ?: return
         queueAccessUnit(mediaCodec, frame.vclNalus)
     }
 
+    /** Tears down any existing codec and builds a fresh one from [currentSps]/[currentPps]. */
     private fun reconfigure() {
         val sps = currentSps ?: return
         val pps = currentPps ?: return
@@ -85,7 +95,7 @@ class VideoDecoder(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 format.setInteger(MediaFormat.KEY_LOW_LATENCY, 1)
             }
-            format.setInteger(MediaFormat.KEY_PRIORITY, 0) // realtime
+            format.setInteger(MediaFormat.KEY_PRIORITY, 0)
 
             val mediaCodec = MediaCodec.createDecoderByType(MediaFormat.MIMETYPE_VIDEO_AVC)
             mediaCodec.configure(format, surface, null, 0)
@@ -98,15 +108,11 @@ class VideoDecoder(
         }
     }
 
+    /** Writes one access unit's NALUs into an input buffer and submits it.
+     * @param mediaCodec the running codec to submit into.
+     * @param nalus every NALU belonging to this access unit, in wire order. */
     private fun queueAccessUnit(mediaCodec: MediaCodec, nalus: List<ByteArray>) {
         try {
-            // Non-blocking dequeue: low latency means "latest frame wins" —
-            // if the codec is momentarily busy, drop rather than wait,
-            // mirroring the Mac encoder's own pendingEncodes backpressure.
-            // But dropping a NAL isn't free on H.264: P-frames reference the
-            // previous decoded frame, so a dropped access unit corrupts every
-            // frame after it until a fresh IDR arrives — request one instead
-            // of waiting for the Mac's own periodic keyframe (up to 60s away).
             val index = mediaCodec.dequeueInputBuffer(0)
             if (index < 0) {
                 signalDesync()
@@ -153,11 +159,14 @@ class VideoDecoder(
         }
     }
 
+    /** Renders every output buffer the codec currently has ready, and reports a
+     * real output size once the codec settles on one.
+     * @param mediaCodec the running codec to drain. */
     private fun drainOutput(mediaCodec: MediaCodec) {
         while (true) {
             val outIndex = mediaCodec.dequeueOutputBuffer(bufferInfo, 0)
             when {
-                outIndex >= 0 -> mediaCodec.releaseOutputBuffer(outIndex, true) // render ASAP
+                outIndex >= 0 -> mediaCodec.releaseOutputBuffer(outIndex, true)
                 outIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
                     val format = mediaCodec.outputFormat
                     val width = format.getInteger(MediaFormat.KEY_WIDTH)
@@ -165,11 +174,12 @@ class VideoDecoder(
                     Log.info("decoder output format changed: ${width}x$height")
                     onSizeChanged(width, height)
                 }
-                else -> return // INFO_TRY_AGAIN_LATER or the deprecated buffers-changed code
+                else -> return
             }
         }
     }
 
+    /** Stops and releases the codec, if one exists — safe to call more than once. */
     fun release() {
         codec?.let {
             try {


### PR DESCRIPTION
## Summary

- Added KDoc to every class/function that didn't have one yet across `net/`, `video/`, `ui/`, `service/`, and `MainActivity.kt`, with `@param`/`@return` where they add real information.
- Removed mid-function `//` comments from the source. The ones carrying non-obvious rationale (protocol quirks, historical bugs, Android platform gotchas, security-relevant clamping decisions) moved to the new `RATIONALE.md`, organized by file, instead of being lost.
- Kept the GPL-3.0 attribution headers (`// Derived from ...` / `// Copyright ...`) in place — those are a license requirement, not documentation, so they don't belong in RATIONALE.md.
- Fixed two comments that had gone stale: `ReceiverService` still mentioned `ACTION_USER_PRESENT` after that was replaced by `SCREEN_ON` (issue #20's fix), and the `AndroidManifest.xml` POST_NOTIFICATIONS comment claimed a runtime permission request was still a TODO when `MainActivity` already implements it.
- Removed the `// region`/`// endregion` IDE folding markers in `PhoneReceiver.kt` — no content to preserve, just navigation aid.

## Test plan

- [x] `./gradlew compileDebugKotlin` — builds clean
- [x] `./gradlew testDebugUnitTest` — 17/17 unit tests pass
- [x] Manual review of every changed file to confirm no logic changed, only comments/docs

Fixes #42